### PR TITLE
Set URL notice in update_or_create to INFO

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -459,7 +459,7 @@ class Confluence(AtlassianRestAPI):
         else:
             result = self.create_page(space=space, parent_id=parent_id, title=title, body=body)
 
-        log.warning('You may access your page at: {host}{url}'.format(
+        log.info('You may access your page at: {host}{url}'.format(
             host=self.url,
             url=result['_links']['tinyui']))
 


### PR DESCRIPTION
Set the URL notice "You may access your page at: http..." to logging level `INFO` instead of `WARNING`.

Closes #129 