### PR TITLE
Issue: NameError: name 'log' is not defined

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1,5 +1,5 @@
 # coding: utf8
-import logging
+import logging as log 
 from requests.exceptions import HTTPError
 from .rest_client import AtlassianRestAPI
 


### PR DESCRIPTION
Error: NameError: name 'log' is not defined

cause: logging referenced as log in jira.py but not imported as it.
solution:
import logging as log
