### PR TITLE
Support HTTP status code 201 in rest_client

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -79,6 +79,8 @@ class AtlassianRestAPI(object):
             response_content = response.content
         if response.status_code == 200:
             log.debug('Received: {0}\n {1}'.format(response.status_code, response_content))
+        elif response.status_code == 201:
+            log.debug('Received: {0}\n "Created" response'.format(response.status_code))
         elif response.status_code == 204:
             log.debug('Received: {0}\n "No Content" response'.format(response.status_code))
         elif response.status_code == 404:


### PR DESCRIPTION
201 is a valid HTTP status code when doing POST method, it means the resource has been created.
So we shouldn't show error log for status 201.

Below is what I encountered in real case:
```
DEBUG:atlassian:Received: 201
 <Response [201]>
DEBUG:atlassian:curl --silent -X POST -u '*****':'********' -H 'Content-Type: application/json' -H 'Accept: application/json' --data '"{\"fields\": {\"project\": {\"key\": \"GIS\"}, \"issuetype\": {\"name\": \"Golden Image\"}, \"summary\": \"Test Subject\"}}"' 'https://example.com'
ERROR:atlassian:{u'self': u'https://example.com/rest/api/2/issue/11793', u'id': u'11793', u'key': u'GIS-10'}
```