### PR TITLE
Added delete_issue_remotelink_by_link_id

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -621,6 +621,11 @@ class Jira(AtlassianRestAPI):
         return self.post(url, data=data)
     
     def delete_issue_remotelink_by_link_id(self, issue_key, link_id):
+        """
+        Deletes Remote Link on Issue
+        :param issue_key: str
+        :param link_id: str
+        """
         url = 'rest/api/2/issue/{issue_key}/remotelink/{link_id}'.format(issue_key=issue_key, link_id=link_id)
         return self.delete(url)
 

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -618,8 +618,11 @@ class Jira(AtlassianRestAPI):
             data['globalId'] = global_id
         if relationship:
             data['relationship'] = relationship
-        print(data)
         return self.post(url, data=data)
+    
+    def delete_issue_remotelink_by_link_id(self, issue_key, link_id):
+        url = 'rest/api/2/issue/{issue_key}/remotelink/{link_id}'.format(issue_key=issue_key, link_id=link_id)
+        return self.delete(url)
 
     def get_issue_transitions(self, issue_key):
         url = 'rest/api/2/issue/{issue_key}?expand=transitions.fields&fields=status'.format(issue_key=issue_key)

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -174,6 +174,9 @@ Manage issues
     
     # Create or Update Issue Links
     jira.create_or_update_issue_remotelinks(issue_key, link_url, title, global_id=None, relationship=None)
+    
+    # Delete Issue Links
+    jira.delete_issue_remotelink_by_link_id(issue_key, link_id)
 
 Attachments actions
 -------------------


### PR DESCRIPTION
Updated the docs to match as well. 

Unfortunately, I haven't found a way to prevent the printing of the response in create_or_update_remotelinks. I don't know if there's a way to suppress that that I'm just not seeing, or if it's just the way it works, so I hadn't updated it. If you know how to, feel free to add that or let me know how to do it.

I plan on adding the application portion to the create_or_update_issue_remotelinks, but I can only access Jira and Confluence while at work and our Jira is in the process of being upgraded so the Jira to Confluence link is broken at the moment, so I'm unable to test.