### PR TITLE
FIX Bamboo.results() function - add missing 'label' parameter

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -41,7 +41,7 @@ class Bamboo(AtlassianRestAPI):
                 yield r
             start_index += results['max-result']
 
-    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, start_index=0, **kwargs):
+    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, label, start_index=0, **kwargs):
         flags = []
         params = {'max-results': max_results}
         if expand:
@@ -50,6 +50,8 @@ class Bamboo(AtlassianRestAPI):
             flags.append('favourite')
         if clover_enabled:
             flags.append('cloverEnabled')
+        if label:
+            params['label'] = label
         params.update(kwargs)
         if 'elements_key' in kwargs and 'element_key' in kwargs:
             return self._get_generator(self.resource_url(resource), flags=flags, params=params,
@@ -81,7 +83,7 @@ class Bamboo(AtlassianRestAPI):
                                    elements_key='plans', element_key='plan')
 
     def results(self, project_key=None, plan_key=None, job_key=None, build_number=None, expand=None, favourite=False,
-                clover_enabled=False, issue_key=None, start_index=0, max_results=25):
+                clover_enabled=False, issue_key=None, label=None, start_index=0, max_results=25):
         """
         Get results as generic method
         :param project_key:
@@ -111,9 +113,9 @@ class Bamboo(AtlassianRestAPI):
             params['issueKey'] = issue_key
         return self.base_list_call(resource, expand=expand, favourite=favourite, clover_enabled=clover_enabled,
                                    start_index=start_index, max_results=max_results,
-                                   elements_key='results', element_key='result', **params)
+                                   elements_key='results', element_key='result', label=label, **params)
 
-    def latest_results(self, expand=None, favourite=False, clover_enabled=False, label=None, issue_key=None,
+    def  latest_results(self, expand=None, favourite=False, clover_enabled=False, label=None, issue_key=None,
                        start_index=0, max_results=25):
         """
         Get latest Results

--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -115,7 +115,7 @@ class Bamboo(AtlassianRestAPI):
                                    start_index=start_index, max_results=max_results,
                                    elements_key='results', element_key='result', label=label, **params)
 
-    def  latest_results(self, expand=None, favourite=False, clover_enabled=False, label=None, issue_key=None,
+    def latest_results(self, expand=None, favourite=False, clover_enabled=False, label=None, issue_key=None,
                        start_index=0, max_results=25):
         """
         Get latest Results


### PR DESCRIPTION
This PR should fix an error when you try to use functions, which refer to the "results" function
`Traceback (most recent call last):
  File "/Users/dmitrij.djachkov/Code/Bamboo/bamboo_cleaner.py", line 14, in <module>
    for result in bamboo.plan_results(project_key='TEST', plan_key='TESTPLAN'):
  File "/Users/dmitrij.djachkov/Code/atlas-python/lib/python3.7/site-packages/atlassian/bamboo.py", line 165, in plan_results
    label=label, issue_key=issue_key, start_index=start_index, max_results=max_results)
TypeError: results() got an unexpected keyword argument 'label'`

