### PR TITLE
Bamboo: fix error in base_list_call()

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -41,7 +41,7 @@ class Bamboo(AtlassianRestAPI):
                 yield r
             start_index += results['max-result']
 
-    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, label, start_index=0, **kwargs):
+    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, label=None, start_index=0, **kwargs):
         flags = []
         params = {'max-results': max_results}
         if expand:


### PR DESCRIPTION
Fixing `TypeError: base_list_call() missing 1 required positional argument: 'label'`