### PR TITLE
Rename set_issue_status_by_id and update jira.rst

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -927,7 +927,7 @@ class Jira(AtlassianRestAPI):
         transition_id = self.get_transition_id_to_status_name(issue_key, status_name)
         return self.post(url, data={'transition': {'id': transition_id}})
 
-    def set_issue_status_by_id(self, issue_key, transition_id):
+    def set_issue_status_by_transition_id(self, issue_key, transition_id):
         """
         Setting status by transition_id
         :param issue_key: str

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -172,6 +172,9 @@ Manage issues
     # Set issue status
     jira.set_issue_status(issue_key, status_name)
 
+    # Set issue status by transition_id
+    jira.set_issue_status_by_transition_id(issue_key, transition_id)
+    
     # Get issue status
     jira.get_issue_status(issue_key)
     


### PR DESCRIPTION
The set_issue_status_by_id method sets the status not by task id, but by the transaction id.