### PR TITLE
Fix undefined name 'permission' in project_remove_user_permissions

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -117,7 +117,6 @@ class Bitbucket(AtlassianRestAPI):
         """
         url = 'rest/api/1.0/projects/{project_key}/permissions/users?name={username}'.format(
             project_key=project_key,
-            permission=permission,
             username=username)
         return self.delete(url)
 


### PR DESCRIPTION
Can't find any 'permission' parameter to implement in documentation.
https://docs.atlassian.com/bitbucket-server/rest/4.5.1/bitbucket-rest.html#idp2397808