### PR TITLE
issue 280: implement the new method confluence.attach_content()

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -390,6 +390,49 @@ class Confluence(AtlassianRestAPI):
                 'body': self._create_body(text, 'storage')}
         return self.post('rest/api/content/', data=data)
 
+    def attach_content(self, content, name, content_type='application/binary', page_id=None, title=None, space=None, comment=None):
+        """
+        Attach (upload) a file to a page, if it exists it will update the
+        automatically version the new file and keep the old one.
+        :param title: The page name
+        :type  title: ``str``
+        :param space: The space name
+        :type  space: ``str``
+        :param page_id: The page id to which we would like to upload the file
+        :type  page_id: ``str``
+        :param name: The name of the attachment
+        :type  name: ``str``
+        :param content: Contains the content which should be uplaoded
+        :type  content: ``binary``
+        :param content_type: Specify the HTTP content type. The default is
+        :type  content_type: ``str``
+        :param comment: A comment describing this upload/file
+        :type  comment: ``str``
+        """
+        page_id = self.get_page_id(space=space, title=title) if page_id is None else page_id
+        type = 'attachment'
+        if page_id is not None:
+            comment = comment if comment else "Uploaded {filename}.".format(filename=name)
+            data = {
+                'type': type,
+                "fileName": name,
+                "contentType": content_type,
+                "comment": comment,
+                "minorEdit": "true"}
+            headers = {
+                'X-Atlassian-Token': 'nocheck',
+                'Accept': 'application/json'}
+            path = 'rest/api/content/{page_id}/child/attachment'.format(page_id=page_id)
+            # Check if there is already a file with the same name
+            attachments = self.get(path=path, headers=headers, params={'filename': name})
+            if attachments['size']:
+                path = path + '/' + attachments['results'][0]['id'] + '/data'
+            return self.post(path=path, data=data, headers=headers,
+                             files={'file': (name, content, content_type)})
+        else:
+            log.warning("No 'page_id' found, not uploading attachments")
+            return None
+
     def attach_file(self, filename, page_id=None, title=None, space=None, comment=None):
         """
         Attach (upload) a file to a page, if it exists it will update the

--- a/docs/confluence.rst
+++ b/docs/confluence.rst
@@ -92,6 +92,10 @@ Page actions
     # automatically version the new file and keep the old one
     confluence.attach_file(filename, page_id=None, title=None, space=None, comment=None)
 
+    # Attach (upload) a content to a page, if it exists it will update the
+    # automatically version the new file and keep the old one
+    confluence.attach_content(content, name=None, content_type=None, page_id=None, title=None, space=None, comment=None)
+
     # Export page as PDF
     # api_version needs to be set to 'cloud' when exporting from Confluence Cloud. 
     confluence.export_page(page_id)

--- a/tests/test-confluence-attach.py
+++ b/tests/test-confluence-attach.py
@@ -5,9 +5,9 @@ import unittest
 from atlassian import Confluence
 
 
-class TestConfluenceAuth(unittest.TestCase):
+class TestConfluenceAttach(unittest.TestCase):
 
-    def test_confluence_auth(self):
+    def test_confluence_attach(self):
         credentials = None
         secret_file = '../credentials.secret'
 

--- a/tests/test-confluence-attach.py
+++ b/tests/test-confluence-attach.py
@@ -60,6 +60,41 @@ class TestConfluenceAttach(unittest.TestCase):
         os.close(fd)
         os.remove(filename)
 
+    def test_confluence_attach_data(self):
+        credentials = None
+
+        try:
+            with open(self.secret_file) as json_file:
+                credentials = json.load(json_file)
+        except Exception as err:
+            self.fail('[{0}]: {1}'.format(self.secret_file, err))
+
+        confluence = Confluence(
+            url=credentials['host'],
+            username=credentials['username'],
+            password=credentials['password'])
+
+        # individual configuration
+        space = 'SAN'
+        title = 'atlassian-python-rest-api-wrapper'
+
+        attachment_name = os.path.basename(tempfile.mktemp())
+
+        # upload a new file
+        content = b'Hello World - Version 1'
+        result = confluence.attach_content( content, attachment_name, 'text/plain', title=title, space=space, comment='upload from unittest')
+
+        # attach_file() returns: {'results': [{'id': 'att144005326', 'type': 'attachment', ...
+        self.assertTrue('results' in result)
+        self.assertFalse('statusCode' in result)
+
+        # upload a new version of an existing file
+        content = b'Hello Universe - Version 2'
+        result = confluence.attach_content( content, attachment_name, 'text/plain', title=title, space=space, comment='upload from unittest')
+
+        # attach_file() returns: {'id': 'att144005326', 'type': 'attachment', ...
+        self.assertTrue('id' in result)
+        self.assertFalse('statusCode' in result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test-confluence-attach.py
+++ b/tests/test-confluence-attach.py
@@ -6,27 +6,27 @@ from atlassian import Confluence
 
 
 class TestConfluenceAttach(unittest.TestCase):
+    secret_file = '../credentials.secret'
+
+    '''
+        Keep the credentials private, the file is excluded. There is an example for credentials.secret
+        See also: http://www.blacktechdiva.com/hide-api-keys/
+
+        {
+          "host" : "https://localhost:8080",
+          "username" : "john_doe",
+          "password" : "12345678"
+        }        
+    '''
 
     def test_confluence_attach(self):
         credentials = None
-        secret_file = '../credentials.secret'
-
-        '''
-            Keep the credentials private, the file is excluded. There is an example for credentials.secret
-            See also: http://www.blacktechdiva.com/hide-api-keys/
-            
-            {
-              "host" : "https://localhost:8080",
-              "username" : "john_doe",
-              "password" : "12345678"
-            }        
-        '''
 
         try:
-            with open(secret_file) as json_file:
+            with open(self.secret_file) as json_file:
                 credentials = json.load(json_file)
         except Exception as err:
-            self.fail('[{0}]: {1}'.format(secret_file, err))
+            self.fail('[{0}]: {1}'.format(self.secret_file, err))
 
         confluence = Confluence(
             url=credentials['host'],


### PR DESCRIPTION
I implement a new method called attach_content() in the confluence module. This new method is very similar to attach_file(). See #280 for more details.

The overall diff log looks a little bit confusing here in Github, because single steps are combined. Avoid duplicate code attach_file() uses now attach_content()