### PR TITLE
Issue 286: Confluence.get_page_by_title() works like Confluence.get_page_by_id()

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -103,9 +103,10 @@ class Confluence(AtlassianRestAPI):
                  If it has IndexError then return the None.
         """
         url = 'rest/api/content'
-        params = {}
-        params['start'] = 0
-        params['limit'] = 1
+        params = {
+            'start': '0',
+            'limit': '1'
+        }
         if expand is not None:
             params['expand'] = expand
         if space is not None:

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -92,24 +92,22 @@ class Confluence(AtlassianRestAPI):
         """
         return ((self.get_page_by_id(page_id, expand='space') or {}).get('space') or {}).get('key')
 
-    def get_page_by_title(self, space, title, start=None, limit=None):
+    def get_page_by_title(self, space, title, expand=None):
         """
         Returns the list of labels on a piece of Content.
         :param space: Space key
         :param title: Title of the page
-        :param start: OPTIONAL: The start point of the collection to return. Default: None (0).
-        :param limit: OPTIONAL: The limit of the number of labels to return, this may be restricted by
-                            fixed system limits. Default: 200.
+        :param expand: OPTIONAL: expand e.g. history
         :return: The JSON data returned from searched results the content endpoint, or the results of the
                  callback. Will raise requests.HTTPError on bad input, potentially.
                  If it has IndexError then return the None.
         """
         url = 'rest/api/content'
         params = {}
-        if start is not None:
-            params['start'] = int(start)
-        if limit is not None:
-            params['limit'] = int(limit)
+        params['start'] = 0
+        params['limit'] = 1
+        if expand is not None:
+            params['expand'] = expand
         if space is not None:
             params['spaceKey'] = str(space)
         if space is not None:


### PR DESCRIPTION
Attention: If anyone use parameter start and limit to call Confluence.get_page_by_title() he will get an TypeError exception