### PR TITLE
Add method to get pull request comment by id to bitbucket class

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -669,7 +669,8 @@ class Bitbucket(AtlassianRestAPI):
         :param comment_id: the ID of the comment to retrieve
         :return:
         """
-        url = 'rest/api/1.0/projects/{project}/repos/{repository}/pull-requests/{pullRequestId}/comments/{comment_id}'.format(
+        url = ('rest/api/1.0/projects/{project}/repos/{repository}'
+               '/pull-requests/{pullRequestId}/comments/{comment_id}').format(
             project=project,
             repository=repository,
             pullRequestId=pull_request_id,

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -658,6 +658,24 @@ class Bitbucket(AtlassianRestAPI):
         body = {'text': text}
         return self.post(url, data=body)
 
+    def get_pull_request_comment(self, project, repository, pull_request_id, comment_id):
+        """
+        Retrieves a pull request comment.
+        The authenticated user must have REPO_READ permission
+        for the repository that this pull request targets to call this resource.
+        :param project:
+        :param repository:
+        :param pull_request_id: the ID of the pull request within the repository
+        :param comment_id: the ID of the comment to retrieve
+        :return:
+        """
+        url = 'rest/api/1.0/projects/{project}/repos/{repository}/pull-requests/{pullRequestId}/comments/{comment_id}'.format(
+            project=project,
+            repository=repository,
+            pullRequestId=pull_request_id,
+            comment_id=comment_id)
+        return self.get(url)
+
     def get_pullrequest(self, project, repository, pull_request_id):
         """
         Retrieve a pull request.


### PR DESCRIPTION
Add method to retrieve pull request comments by comment_id.
documentation:
https://docs.atlassian.com/bitbucket-server/rest/6.4.1/bitbucket-rest.html#idp281