### PR TITLE
Set response encoding to utf-8

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -125,6 +125,7 @@ class AtlassianRestAPI(object):
             verify=self.verify_ssl,
             files=files
         )
+        response.encoding = 'utf-8'
         if self.advanced_mode:
             self.response = response
             return response


### PR DESCRIPTION
For every request the requests module guesses the correct encoding, which takes time.

Therefore this commit sets the encoding to uft-8.

From https://2.python-requests.org/en/master/user/quickstart/ 

>>>
Requests will automatically decode content from the server. Most unicode charsets are seamlessly decoded.

When you make a request, Requests makes educated guesses about the encoding of the response based on the HTTP headers. The text encoding guessed by Requests is used when you access r.text. You can find out what encoding Requests is using, and change it, using the r.encoding property:

 r.encoding
'utf-8'
 r.encoding = 'ISO-8859-1'

If you change the encoding, Requests will use the new value of r.encoding whenever you call r.text. You might want to do this in any situation where you can apply special logic to work out what the encoding of the content will be. For example, HTML and XML have the ability to specify their encoding in their body. In situations like this, you should use r.content to find the encoding, and then set r.encoding. This will let you use r.text with the correct encoding.