### PR TITLE
add limit restriction for get_all_pages_from_space

### DIFF
--- a/docs/confluence.rst
+++ b/docs/confluence.rst
@@ -35,8 +35,9 @@ Get page info
 
     # Get all pages from Space
     # contet_type can be 'page' or 'blogpost'. Defaults to 'page'
-    # expand is a comma separated list of properties to expand on the content. 
-    confluence.get_all_pages_from_space(space, start=0, limit=500, status=None, expand=None, content_type='page')
+    # expand is a comma separated list of properties to expand on the content.
+    # max limit is 100. For more you have to loop over start values.
+    confluence.get_all_pages_from_space(space, start=0, limit=100, status=None, expand=None, content_type='page')
 
     # Get list of pages from trash
     confluence.get_all_pages_from_space_trash(space, start=0, limit=500, status='trashed', content_type='page')


### PR DESCRIPTION
I tested and found that the max number of articles one can get by calling *get_all_pages_from_space* is 100. I think it would be useful to add that to the documentation.