### PR TITLE
Kerberos authentication support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,29 @@ Alternatively OAuth can be used:
         url='http://localhost:8080',
         oauth=oauth_dict)
 
+Or Kerberos:
+
+.. code-block:: python
+
+    kerberos_service = 'HTTP/jira.localhost@YOUR.DOMAIN.COM'
+
+    jira = Jira(
+        url='http://localhost:8080',
+        kerberos=kerberos_service)
+
+    confluence = Confluence(
+        url='http://localhost:8090',
+        kerberos=kerberos_service)
+
+    bitbucket = Bitbucket(
+        url='http://localhost:7990',
+        kerberos=kerberos_service)
+
+    service_desk = ServiceDesk(
+        url='http://localhost:8080',
+        kerberos=kerberos_service)
+
+
 .. toctree::
    :maxdept:2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ six
 requests
 oauthlib
 requests_oauthlib
+kerberos; platform_system != 'Windows'
+kerberos-sspi; platform_system == 'Windows'

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'six',
         'oauthlib',
         'requests_oauthlib'
-    ] + ['kerberos-sspi'] if "win" in sys.platform else ['kerberos'],
+    ] + (['kerberos-sspi'] if "win" in sys.platform else ['kerberos']),
     platforms='Platform Independent',
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from setuptools import find_packages
 from setuptools import setup
 
@@ -31,7 +32,7 @@ setup(
         'six',
         'oauthlib',
         'requests_oauthlib'
-    ],
+    ] + ['kerberos-sspi'] if "win" in sys.platform else ['kerberos'],
     platforms='Platform Independent',
 
     classifiers=[


### PR DESCRIPTION
Support for Kerberos authentication (#322). Unfortunately the Windows package differs from the rest of the world.

[requests-kerberos](https://github.com/requests/requests-kerberos) could be a better choice but I was unable to get it working on Windows. Every attempt ended in https://github.com/requests/requests-kerberos/issues/96.

This is still a draft because I couldn't figure out what's wrong with the _tox_ builds yet. Pytest works locally though.