### PR TITLE
sys.platform => platform_system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,10 @@ setup(
         'requests',
         'six',
         'oauthlib',
-        'requests_oauthlib'
-    ] + (['kerberos-sspi'] if "win32" in sys.platform else ['kerberos']),
+        'requests_oauthlib',
+        'kerberos-sspi;platform_system=="Windows"',
+        'kerberos;platform_system!="Windows"'
+    ],
     platforms='Platform Independent',
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'six',
         'oauthlib',
         'requests_oauthlib'
-    ] + (['kerberos-sspi'] if "win" in sys.platform else ['kerberos']),
+    ] + (['kerberos-sspi'] if "win32" in sys.platform else ['kerberos']),
     platforms='Platform Independent',
 
     classifiers=[


### PR DESCRIPTION
To determine the window, check the win32. With the verification that is now, there will be problems in the Mac OS:
```
$ python
Python 3.7.4 (default, Jul  9 2019, 18:15:00)
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> sys.platform
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'sys' is not defined
>>> import sys
>>> sys.platform
'darwin'
>>>
$ sw_vers
ProductName:  Mac OS X
ProductVersion:  10.14
BuildVersion:  18A391
```
https://docs.python.org/3/library/sys.html#sys.platform