### PR TITLE
Log level of package imports adjusted

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -52,11 +52,11 @@ class AtlassianRestAPI(object):
         try:
             import kerberos as kerb
         except ImportError as e:
-            log.error(e)
+            log.debug(e)
             try:
                 import kerberos_sspi as kerb
             except ImportError:
-                log.info("Please, fix issue with dependency of kerberos")
+                log.error("Please, fix issue with dependency of kerberos")
                 return
         __, krb_context = kerb.authGSSClientInit(kerberos_service)
         kerb.authGSSClientStep(krb_context, "")


### PR DESCRIPTION
The error message on the first import is a little misleading on windows: it appears always, but everything is ok. I'm not sure if is is needed anyway since the import error is a valid case on windows.

For the second message: Does it make sense to throw an error here? At this point it's not possible to continue with a valid state.