### PR TITLE
Optional Kerberos dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,12 @@ setup(
         'requests',
         'six',
         'oauthlib',
-        'requests_oauthlib',
-        'kerberos-sspi ; platform_system=="Windows"',
-        'kerberos ; platform_system!="Windows"'
+        'requests_oauthlib'
     ],
+    extras_require={
+        'kerberos': ['kerberos-sspi ; platform_system=="Windows"',
+                     'kerberos ; platform_system!="Windows"']
+    },
     platforms='Platform Independent',
 
     classifiers=[


### PR DESCRIPTION
A first attempt to make the _kerberos_ dependency optional (#349).

```sh
# default - no kerberos dependency
> pip install atlassian-python-api

# kerberos dependency included
> pip install atlassian-python-api[kerberos]
```



### Open issues

- [ ] How to handle requirements.txt (separate file)?
- [ ] Update documentation (especially how to install extra dependencies).
- [ ] Are CI tests for both version available?
- [ ] Calling kerberos authentication without supplying the dependency should cause a failure.
- [ ] How to get both use cases into pip? (Or does it already work via `setup.py`?)
