### PR TITLE
Kerberos follow-up

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -56,8 +56,7 @@ class AtlassianRestAPI(object):
             try:
                 import kerberos_sspi as kerb
             except ImportError:
-                log.error("Please, fix issue with dependency of kerberos")
-                return
+                raise ImportError("No kerberos implementation available")
         __, krb_context = kerb.authGSSClientInit(kerberos_service)
         kerb.authGSSClientStep(krb_context, "")
         auth_header = ("Negotiate " + kerb.authGSSClientResponse(krb_context))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,7 +69,7 @@ Alternatively OAuth can be used:
         url='http://localhost:8080',
         oauth=oauth_dict)
 
-Or Kerberos:
+Or Kerberos *(installation with kerberos extra necessary)*:
 
 .. code-block:: python
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ skip_missing_interpreters = True
 [testenv]
 deps = pytest
 commands = pytest -v
+extras = kerberos


### PR DESCRIPTION
Some open issues mentioned in #353 fixed:

1. Exception if kerberos is used but not installed
1. Tox config updated to include the extra dependency
1. Note added to the documentation. Is this enough or is a full pip call more suitable?