### PR TITLE
Python 3.7 CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 
 matrix:
   allow_failures:


### PR DESCRIPTION
A Python 3.7 CI build and clean-up of the deprecated `sudo` option.