### PR TITLE
fixing Confluence.remove_page_attachment_keep_version() method

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -520,7 +520,7 @@ class Confluence(AtlassianRestAPI):
         attachment_versions = self.get_attachment_history(attachment.get("id"))
         while len(attachment_versions) > keep_last_versions:
             remove_version_attachment_number = attachment_versions[keep_last_versions].get('number')
-            self.delete_attachment(page_id=page_id, filename=filename, version=remove_version_attachment_number)
+            self.delete_attachment_by_id(attachment_id=attachment.get("id"), version=remove_version_attachment_number)
             log.info(
                 "Removed oldest version for {}, now versions equal more than {}".format(attachment.get('title'),
                                                                                         len(attachment_versions)))


### PR DESCRIPTION
Hi there,

**TL;DR:** This patch intends to fix the `remove_page_attachment_keep_version()` method in the `Confluence` class, so that it only removes (some) of the versions and not the attachment as a whole.

**Background:** I am faced with a Confluence instance that has been around for some years and for reasons™ had several hundreds of times the exact same versions of most of its attachments uploaded to it by a third party Confluence plugin, over and over again. In order to free up dozens of gigabytes of disk space, I am trying to use this library to iterate over the pages in a particular space and for each attachment found on these pages to delete all versions of the attachments except the most recent ones. The `remove_page_attachment_keep_version()` method seems to be intend to do just that.

**Problem:** When using the function with a given attachment and a number of versions to keep (m), it gets a list of all versions (n), then starts a while-loop deleting the version n-m of the attachment, until only m versions remain. Unfortunately the method `Confluence.delete_attachment()` seems to ignore the `version` parameter and always deletes the whole attachment. This causes an infinite loop, as it doesn't find the new version count, but gets a 403 error instead as the attachment isn't there anymore.

**Partial solution:** I noticed the `Confluence.delete_attachment_by_id()` function just below uses a different API call with an explicit version being required. Since we already have the attachment object including ID available in `remove_page_attachment_keep_version()` we can fix it by simply using that other deletion method.

**Conclusion:** This PR doesn't address the non-working `version` parameter in the `Confluence.delete_attachment()` method. I didn't touch it, as I don't know what other functionality may rely on it. Maybe it could be rewritten to use the `Confluence.delete_attachment_by_id()` when a version is provided and otherwise keep using the existing logic? Hope this PR serves to prevent others from deleting their attachments accidentally. Luckily we use testing instances. :-)