### PR TITLE
fix/change the parameter filter of get_tags to be filterText

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -878,7 +878,7 @@ class Bitbucket(AtlassianRestAPI):
         if limit:
             params['limit'] = limit
         if filter:
-            params['filter'] = filter
+            params['filterText'] = filter
         if order_by:
             params['orderBy'] = order_by
         result = self.get(url, params=params)


### PR DESCRIPTION
Hi,

according to this page
https://metacpan.org/pod/WebService::BitbucketServer::Core::V1#get_tags
the name of the parameter for the filtering is filterText.