### PR TITLE
stop_build method added to a bamboo.py

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -369,6 +369,15 @@ class Bamboo(AtlassianRestAPI):
 
         return self.post(self.resource_url(resource), params=params, headers=headers)
 
+    def stop_build(self, plan_key):
+        """
+        Stop the build which is in progress now plan. 
+        :param plan_key: str TST-BLD
+        :return: DELETE request
+        """
+        resource = "/build/admin/stopPlan.action?planKey={}".format(plan_key)
+        return self.delete(resource)
+
     """ Comments & Labels """
 
     def comments(self, project_key, plan_key, build_number, start_index=0, max_results=25):


### PR DESCRIPTION
Immediately stop a build for a given PROJ-KEY. Equivalent to "Stop Build" button in GUI.