### PR TITLE
Wrap label in quotes to handle labels with dashes.

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -249,7 +249,7 @@ class Confluence(AtlassianRestAPI):
         url = 'rest/api/content/search'
         params = {}
         if label:
-            params['cql'] = 'type={type} AND label={label}'.format(type='page',
+            params['cql'] = 'type={type} AND label="{label}"'.format(type='page',
                                                                    label=label)
         if start:
             params['start'] = start


### PR DESCRIPTION
Using get_all_pages_by_label returned a 400 when the label included dashes (e.g. test-label-with-dashes).

Wrapped the label in quotes when building the cql query.