### PR TITLE
Include title in determining if there is a difference

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -783,7 +783,7 @@ class Confluence(AtlassianRestAPI):
         """
         log.info('Updating {type} "{title}"'.format(title=title, type=type))
 
-        if self.is_page_content_is_already_updated(page_id, append_body):
+        if self.is_page_content_is_already_updated(page_id, append_body, title):
             return self.get_page_by_id(page_id)
         else:
             version = self.history(page_id)['lastUpdated']['number'] + 1


### PR DESCRIPTION
## Problem
I hit this issue, https://github.com/atlassian-api/atlassian-python-api/issues/317 as well when I was trying to update just the title of a confluence page. The current method in determining if an update only considers the body content of the confluence page.

## Solution
Include the title in comparing page content.

## Areas of impact
Updating confluence pages.