### PR TITLE
Improve error handling

### DIFF
--- a/atlassian/errors.py
+++ b/atlassian/errors.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+
+class ApiError(Exception):
+    pass
+
+class ApiNotFoundError(ApiError):
+    pass
+
+class ApiPermissionError(ApiError):
+    pass
+
+class ApiValueError(ApiError):
+    pass
+
+class ApiConflictError(ApiError):
+    pass

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -151,45 +151,12 @@ class AtlassianRestAPI(object):
             files=files
         )
         response.encoding = 'utf-8'
+
         if self.advanced_mode:
-            self.response = response
             return response
-        try:
-            if response.text:
-                response_content = response.json()
-            else:
-                response_content = response.content
-        except ValueError:
-            response_content = response.content
-        if response.status_code == 200:
-            log.debug('Received: {0}\n {1}'.format(response.status_code, response_content))
-        elif response.status_code == 201:
-            log.debug('Received: {0}\n "Created" response'.format(response.status_code))
-        elif response.status_code == 204:
-            log.debug('Received: {0}\n "No Content" response'.format(response.status_code))
-        elif response.status_code == 400:
-            log.error('Received: {0}\n Bad request \n {1}'.format(response.status_code, response_content))
-        elif response.status_code == 401:
-            log.error('Received: {0}\n "UNAUTHORIZED" response'.format(response.status_code))
-        elif response.status_code == 404:
-            log.error('Received: {0}\n Not Found'.format(response.status_code))
-        elif response.status_code == 403:
-            log.error('Received: {0}\n Forbidden. Please, check permissions'.format(response.status_code))
-        elif response.status_code == 405:
-            log.error('Received: {0}\n Method not allowed'.format(response.status_code))
-        elif response.status_code == 409:
-            log.error('Received: {0}\n Conflict \n {1}'.format(response.status_code, response_content))
-        elif response.status_code == 413:
-            log.error('Received: {0}\n Request entity too large'.format(response.status_code))
-        else:
-            log.debug('Received: {0}\n {1}'.format(response.status_code, response))
-            self.log_curl_debug(method=method, path=path, headers=headers, data=data, level=logging.DEBUG)
-            log.error(response_content)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError as err:
-                log.error("HTTP Error occurred")
-                log.error('Response is: {content}'.format(content=err.response.content))
+
+        log.debug(f'HTTP: {method} {path} -> {response.status_code} {response.reason}')
+        response.raise_for_status()
         return response
 
     def get(self, path, data=None, flags=None, params=None, headers=None, not_json_response=None, trailing=None):


### PR DESCRIPTION
This is a suggestion for implementing better error handling as noted in #257.

**Overview**
* rest_client.AtlassianRestAPI.request: Propagate errors from requests by using the `raise_for_status` method in the response object.
* errors: Define custom exception classes.
* confluence: Use exception chaining to raise the custom exceptions to convey more useful information when possible.

**Notes**
* The improved error handling is implemented for Confluence only right now. This is the Atlassian product I use (and can thus test) most right now. It also appears to have a smaller API surface than Jira for instance.
* I wasn't completely sure about the coding style, but attempted to shorten the exception messages to a reasonable length.
* The names of the custom exception classes could probably be better, but this is probably easier to improve once more products and cases are implemented.
* The error messages are (almost) verbatim copies from the API documentation, but could perhaps also be normalized.

I don't expect this to be merged as is. I only made the changes and this pull request to test and show this approach.

Any feedback appreciated.