### PR TITLE
remove unicode errors

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -669,8 +669,8 @@ class Confluence(AtlassianRestAPI):
             # @todo move into utils
             confluence_content = utils.symbol_normalizer(confluence_content)
 
-        log.debug('Old Content: """{body}"""'.format(body=confluence_content))
-        log.debug('New Content: """{body}"""'.format(body=body))
+        log.debug(u'Old Content: """{body}"""'.format(body=confluence_content))
+        log.debug(u'New Content: """{body}"""'.format(body=body))
 
         if confluence_content == body:
             log.warning('Content of {page_id} is exactly the same'.format(page_id=page_id))


### PR DESCRIPTION
Remove unicode errors on debug output.

I was seeing this on certain page updates:
```
....
  File "/usr/local/lib/python2.7/site-packages/atlassian/confluence.py", line 779, in update_or_create
    representation=representation, minor_edit=minor_edit)
  File "/usr/local/lib/python2.7/site-packages/atlassian/confluence.py", line 705, in update_page
    if self.is_page_content_is_already_updated(page_id, body):
  File "/usr/local/lib/python2.7/site-packages/atlassian/confluence.py", line 672, in is_page_content_is_already_updated
    log.debug('Old Content: """{body}"""'.format(body=confluence_content))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 2731: ordinal not in range(128)
```

After making this a unicode string all was well.