### PR TITLE
[Bamboo] Add disable_plan method

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -130,6 +130,15 @@ class Bamboo(AtlassianRestAPI):
         resource = 'rest/api/latest/plan/{}'.format(plan_key)
         return self.delete(resource)
 
+    def disable_plan(self, plan_key):
+        """
+        Disable plan.
+        :param plan_key: str TST-BLD
+        :return: DELETE request
+        """
+        resource = 'plan/{plan_key}/enable'.format(plan_key=plan_key)
+        return self.delete(self.resource_url(resource))
+
     def enable_plan(self, plan_key):
         """
         Enable plan.

--- a/docs/bamboo.rst
+++ b/docs/bamboo.rst
@@ -1,4 +1,4 @@
-Confluence module
+Bamboo module
 =================
 
 Projects & Plans
@@ -26,6 +26,9 @@ Projects & Plans
 
     # Delete a plan (or a plan branch)
     delete_plan(plan_key)
+
+    # Disable plan
+    disable_plan(plan_key)
 
     # Enable plan
     enable_plan(plan_key)


### PR DESCRIPTION
I used this method to batch-disable several Bamboo branches I didn't want running anymore.

The relevant docs on the Atlassian side are at https://docs.atlassian.com/atlassian-bamboo/REST/6.10.4/#d2e4780, which shows the `/plan/{projectKey}-{buildKey}/enable` URL supports both POST to enable a plan and DELETE to disable a plan.

Opportunistic cleanup: the title of the Bamboo docs incorrectly said it was Confluence.