### PR TITLE
Check for if an element is a valid email

### DIFF
--- a/atlassian/utils.py
+++ b/atlassian/utils.py
@@ -5,7 +5,7 @@ import re
 log = logging.getLogger(__name__)
 
 
-def is_email(string):
+def is_email(element):
     """
     >>> is_email('username@example.com')
     True
@@ -15,11 +15,7 @@ def is_email(string):
     True
     """
     email_regex = r'^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$'
-
-    if isinstance(string, str) and not re.match(email_regex, string):
-        return False
-    else:
-        return True
+    return re.match(email_regex, str(element))
 
 
 def html_email(email, title=None):


### PR DESCRIPTION
The current` is_email()` has a faulty check for whether the input argument is an email. It accepts non string arguments but matches the regex only for arguments that are string. For all other argument types ex: integer, the check is returned True. The fix is to cast the argument as `str` and then perform the check