### PR TITLE
Wrappers for Bitbucket Pipelines REST API

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2317,3 +2317,14 @@ class Bitbucket(AtlassianRestAPI):
             }
 
         return self.post(self.resource_url(resource), data=data, trailing=True)
+
+    def stop_pipeline(self, workspace, repository, uuid):
+        """
+        Stop the pipeline specified by ``uuid``.
+        :param uuid: Pipeline identifier (with surrounding {}; NOT the build number)
+
+        See the documentation for the meaning of response status codes.
+        """
+        resource = "repositories/{workspace}/{repository}/pipelines/{uuid}/stopPipeline".format(
+            workspace=workspace, repository=repository, uuid=uuid)
+        return self.post(self.resource_url(resource))

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2273,6 +2273,15 @@ class Bitbucket(AtlassianRestAPI):
                         params={"pagelen": number, "sort": sort_by},
                         trailing=True)
 
+    def get_pipeline(self, workspace, repository, uuid):
+        """
+        Get information about the pipeline specified by ``uuid``.
+        :param uuid: Pipeline identifier (with surrounding {}; NOT the build number)
+        """
+        resource = "repositories/{workspace}/{repository}/pipelines/{uuid}".format(
+            workspace=workspace, repository=repository, uuid=uuid)
+        return self.get(self.resource_url(resource))
+
     def trigger_pipeline(self, workspace, repository, branch="master", revision=None,
                          name=None):
         """

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2257,3 +2257,18 @@ class Bitbucket(AtlassianRestAPI):
         else:
             url = "rest/api/2.0/admin/banner"
         return self.delete(url)
+
+    def get_pipelines(self, workspace, repository, number=10,
+                      sort_by="-created_on"):
+        """
+        Get information about latest pipelines runs.
+
+        :param number: number of pipelines to fetch
+        :param :sort_by: optional key to sort available pipelines for
+        :return: information in form {"values": [...]}
+        """
+        version = "2.0" if self.cloud else "1.0"
+        url = "rest/api/{version}/repositories/{workspace}/{repository}/pipelines/".format(
+            version=version, workspace=workspace, repository=repository)
+        return self.get(url, params={"pagelen": number, "sort": sort_by},
+                        trailing=True)

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2267,10 +2267,10 @@ class Bitbucket(AtlassianRestAPI):
         :param :sort_by: optional key to sort available pipelines for
         :return: information in form {"values": [...]}
         """
-        version = "2.0" if self.cloud else "1.0"
-        url = "rest/api/{version}/repositories/{workspace}/{repository}/pipelines/".format(
-            version=version, workspace=workspace, repository=repository)
-        return self.get(url, params={"pagelen": number, "sort": sort_by},
+        resource = "repositories/{workspace}/{repository}/pipelines/".format(
+            workspace=workspace, repository=repository)
+        return self.get(self.resource_url(resource),
+                        params={"pagelen": number, "sort": sort_by},
                         trailing=True)
 
     def trigger_pipeline(self, workspace, repository, branch="master", revision=None,
@@ -2284,9 +2284,8 @@ class Bitbucket(AtlassianRestAPI):
         3. Specific pipeline (additionally specify ``name``)
         :return: the initiated pipeline; or error information
         """
-        version = "2.0" if self.cloud else "1.0"
-        url = "rest/api/{version}/repositories/{workspace}/{repository}/pipelines/".format(
-            version=version, workspace=workspace, repository=repository)
+        resource = "repositories/{workspace}/{repository}/pipelines/".format(
+            workspace=workspace, repository=repository)
 
         data = {
             "target": {
@@ -2308,4 +2307,4 @@ class Bitbucket(AtlassianRestAPI):
                 "pattern": name,
             }
 
-        return self.post(url, data=data, trailing=True)
+        return self.post(self.resource_url(resource), data=data, trailing=True)

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -2328,3 +2328,34 @@ class Bitbucket(AtlassianRestAPI):
         resource = "repositories/{workspace}/{repository}/pipelines/{uuid}/stopPipeline".format(
             workspace=workspace, repository=repository, uuid=uuid)
         return self.post(self.resource_url(resource))
+
+    def get_pipeline_steps(self, workspace, repository, uuid):
+        """
+        Get information about the steps of the pipeline specified by ``uuid``.
+        :param uuid: Pipeline identifier (with surrounding {}; NOT the build number)
+        """
+        resource = "repositories/{workspace}/{repository}/pipelines/{uuid}/steps/".format(
+            workspace=workspace, repository=repository, uuid=uuid)
+        return self.get(self.resource_url(resource), trailing=True)
+
+    def get_pipeline_step(self, workspace, repository, pipeline_uuid, step_uuid):
+        """
+        Get information about a step of a pipeline, specified by respective UUIDs.
+        :param pipeline_uuid: Pipeline identifier (with surrounding {}; NOT the build number)
+        :param step_uuid: Step identifier (with surrounding {})
+        """
+        resource = "repositories/{w}/{r}/pipelines/{p}/steps/{s}".format(
+            w=workspace, r=repository, p=pipeline_uuid, s=step_uuid)
+        return self.get(self.resource_url(resource))
+
+    def get_pipeline_step_log(self, workspace, repository, pipeline_uuid, step_uuid):
+        """
+        Get log of a step of a pipeline, specified by respective UUIDs.
+        :param pipeline_uuid: Pipeline identifier (with surrounding {}; NOT the build number)
+        :param step_uuid: Step identifier (with surrounding {})
+        :return: byte string log
+        """
+        resource = "repositories/{w}/{r}/pipelines/{p}/steps/{s}/log".format(
+            w=workspace, r=repository, p=pipeline_uuid, s=step_uuid)
+        headers = {"Accept": "application/octet-stream"}
+        return self.get(self.resource_url(resource), headers=headers, not_json_response=True)

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -130,7 +130,8 @@ class AtlassianRestAPI(object):
         :param trailing: bool
         :return:
         """
-        self.log_curl_debug(method=method, path=path, headers=headers, data=data, trailing=None)
+        self.log_curl_debug(method=method, path=path, headers=headers,
+                            data=data, trailing=trailing)
         url = self.url_joiner(self.url, path, trailing)
         if params or flags:
             url += '?'

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -268,3 +268,15 @@ Pipelines management
 
     # Get most recent Pipelines results for repository
     bitbucket.get_pipelines(workspace, repository)
+
+    # Trigger default Pipeline on the latest revision of the master branch
+    bitbucket.trigger_pipeline(workspace, repository)
+
+    # Trigger default Pipeline on the latest revision of the develop branch
+    bitbucket.trigger_pipeline(workspace, repository, branch="develop")
+
+    # Trigger default Pipeline on a specific revision of the develop branch
+    bitbucket.trigger_pipeline(workspace, repository, branch="develop", revision="<40-char hash>")
+
+    # Trigger specific Pipeline on a specific revision of the master branch
+    bitbucket.trigger_pipeline(workspace, repository, revision="<40-char hash>", name="style-check")

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -280,3 +280,6 @@ Pipelines management
 
     # Trigger specific Pipeline on a specific revision of the master branch
     bitbucket.trigger_pipeline(workspace, repository, revision="<40-char hash>", name="style-check")
+
+    # Get specific Pipeline by UUID
+    bitbucket.get_pipeline(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}")

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -286,3 +286,12 @@ Pipelines management
 
     # Stop specific Pipeline by UUID
     bitbucket.stop_pipeline(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}")
+
+    # Get steps of Pipeline specified by UUID
+    bitbucket.get_pipeline_steps(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}")
+
+    # Get step of Pipeline specified by UUIDs
+    bitbucket.get_pipeline_step(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}", "{56d2d8af-6526-4813-a22c-733ec6ecabf3}")
+
+    # Get log of step of Pipeline specified by UUIDs
+    bitbucket.get_pipeline_step_log(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}", "{56d2d8af-6526-4813-a22c-733ec6ecabf3}")

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -260,3 +260,11 @@ Conditions-Reviewers management
 
     # Delete a project condition for specific repository in project
     bitbucket.delete_repo_condition(project_key, repo_key, id_condition)
+
+Pipelines management
+--------------------
+
+.. code-block:: python
+
+    # Get most recent Pipelines results for repository
+    bitbucket.get_pipelines(workspace, repository)

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -283,3 +283,6 @@ Pipelines management
 
     # Get specific Pipeline by UUID
     bitbucket.get_pipeline(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}")
+
+    # Stop specific Pipeline by UUID
+    bitbucket.stop_pipeline(workspace, repository, "{7d6c327d-6336-4721-bfeb-c24caf25045c}")


### PR DESCRIPTION
- originated from #475
- implementation of several Pipelines-related REST APIs
- tested with a small [test repo](https://bitbucket.org/pylipp/test-rest-api-wrapper/addon/pipelines/home#!/) of mine

Side note: I'm used to work with URLs like `https://api.bitbucket.org/2.0/user/repo/pipelines/`, hence I used the `resource_url()` method to construct URLs (I set up a Bitbucket instance as `bb = Bitbucket("https://api.bitbucket.org", api_version="2.0", api_root="")`. I'd find it beneficial if more methods of the `Bitbucket` class used this approach instead of having the `rest/api/` path hardcoded. I'd provide a separate PR if you don't see any objections.