### PR TITLE
Remove unsupported Python versions from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
 language: python
 python:
-    - "2.7"
-    - "3.3"
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
     - "3.9-dev"
-
-matrix:
-  allow_failures:
-    - python: "3.3"
 
 install: pip install tox
 before_script: 


### PR DESCRIPTION
Per https://devguide.python.org/#status-of-python-branches