### PR TITLE
[JIRA] Create Sprint

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2417,6 +2417,33 @@ class Jira(AtlassianRestAPI):
         url = 'rest/agile/1.0/board/{board_id}/properties'.format(board_id=board_id)
         return self.get(url)
 
+    def create_sprint(self, name, board_id, start_date=None, end_date=None, goal=None):
+        """
+        Create a sprint within a board.
+        ! User requires `Manage Sprints` permission for relevant boards.
+
+        :param name: str: Name for the Sprint to be created
+        :param board_id: int: The ID for the Board in which the Sprint will be created
+        :param start_date: str: The Start Date for Sprint in isoformat
+                            example value is "2015-04-11T15:22:00.000+10:00"
+        :param end_date: str: The End Date for Sprint in isoformat
+                            example value is "2015-04-20T01:22:00.000+10:00"
+        :param goal: str: Goal Text for setting for the Sprint
+        :return: Dictionary of response received from the API
+
+        https://docs.atlassian.com/jira-software/REST/8.9.0/#agile/1.0/sprint
+        isoformat can be created with datetime.datetime.isoformat()
+        """
+        url = '/rest/agile/1.0/sprint'
+        data = dict(name=name, originBoardId=board_id)
+        if start_date:
+            data['startDate'] = start_date
+        if end_date:
+            data['endDate'] = end_date
+        if goal:
+            data['goal'] = goal
+        return self.post(url, data=data)
+
     def get_all_sprint(self, board_id, state=None, start=0, limit=50):
         """
         Returns all sprints from a board, for a given board Id.

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -153,9 +153,6 @@ Manage issues
     # Get existing custom fields or find by filter
     get_custom_fields(self, search=None, start=1, limit=50):
 
-    # Rename sprint
-    jira.rename_sprint(sprint_id, name, start_date, end_date)
-
     # Check issue exists
     jira.issue_exists(issue_key)
 
@@ -203,6 +200,19 @@ Manage issues
 
     # Delete Issue Links
     jira.delete_issue_remote_link_by_id(issue_key, link_id)
+
+
+Manage Boards
+-------------
+
+.. code-block:: python
+
+    # Create sprint
+    jira.jira.create_sprint(sprint_name, origin_board_id,  start_datetime, end_datetime, goal)
+
+    # Rename sprint
+    jira.rename_sprint(sprint_id, name, start_date, end_date)
+
 
 Attachments actions
 -------------------

--- a/examples/jira/jira-sprint-create.py
+++ b/examples/jira/jira-sprint-create.py
@@ -1,0 +1,23 @@
+from atlassian import Jira
+
+sprint_name = 'Sprint 2'
+origin_board_id = 1000
+start_datetime = '2021-05-30T14:42:23.643068'
+end_datetime = '2021-06-30T14:42:23.643068'
+goal = "And we're out of beta, we're releasing on time."
+
+
+jira = Jira(
+    url='http://localhost:8080',
+    username='admin',
+    password='admin')
+
+# name and board_id are mandatory only
+# Necessary for user to have `Manage Sprint` permission for the board
+resp = jira.create_sprint(
+                            name=sprint_name,
+                            board_id=origin_board_id,
+                            start_date=start_datetime,
+                            end_date=end_datetime,
+                            goal=goal
+                          )


### PR DESCRIPTION
### Functionality to Create  Sprint

- Added the `create_sprint` functionality within jira
- Placed docs for it in docs/jira.rst - added separate section for **Manage Boards**
- Added example at jira-sprint-create.py

Closes Issue #506