### PR TITLE
feat: nested error for Confluence

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -78,8 +78,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -168,8 +168,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
         try:
@@ -211,8 +211,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -246,8 +246,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -284,8 +284,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -305,8 +305,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -335,7 +335,7 @@ class Confluence(AtlassianRestAPI):
             response = self.get(url, params=params)
         except HTTPError as e:
             if e.response.status_code == 400:
-                raise ApiValueError("The CQL is invalid or missing")(e)
+                raise ApiValueError("The CQL is invalid or missing", reason=e)
 
             raise
 
@@ -378,8 +378,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -435,8 +435,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -485,12 +485,12 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, or the calling "
-                    "user does not have permission to trash or purge the content"
-                )(e)
+                    "user does not have permission to trash or purge the content",
+                    reason=e)
             if e.response.status_code == 409:
                 raise ApiConflictError(
-                    "There is a stale data object conflict when trying to delete a draft"
-                )(e)
+                    "There is a stale data object conflict when trying to delete a draft",
+                    reason=e)
 
             raise
 
@@ -520,12 +520,12 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, or the calling "
-                    "user does not have permission to trash or purge the content"
-                )(e)
+                    "user does not have permission to trash or purge the content",
+                    reason=e)
             if e.response.status_code == 409:
                 raise ApiConflictError(
-                    "There is a stale data object conflict when trying to delete a draft"
-                )(e)
+                    "There is a stale data object conflict when trying to delete a draft",
+                    reason=e)
 
             raise
 
@@ -560,8 +560,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -620,8 +620,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -674,15 +674,15 @@ class Confluence(AtlassianRestAPI):
                     # Raise ApiError as the documented reason is ambiguous
                     raise ApiError(
                         "Attachments are disabled or the calling user does "
-                        "not have permission to add attachments to this content"
-                    )(e)
+                        "not have permission to add attachments to this content",
+                        reason=e)
                 if e.response.status_code == 404:
                     # Raise ApiError as the documented reason is ambiguous
                     raise ApiError(
                         "The requested content is not found, the user does not have "
                         "permission to view it, or the attachments exceeds the maximum "
-                        "configured attachment size"
-                    )(e)
+                        "configured attachment size",
+                        reason=e)
 
                 raise
 
@@ -811,8 +811,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -836,8 +836,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -860,14 +860,14 @@ class Confluence(AtlassianRestAPI):
             if e.response.status_code == 403:
                 raise ApiPermissionError(
                     "The user has view permission, "
-                    "but no edit permission to the content"
-                )(e)
+                    "but no edit permission to the content",
+                    reason=e)
             if e.response.status_code == 404:
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "The content or label doesn't exist, "
-                    "or the calling user doesn't have view permission to the content"
-                )(e)
+                    "or the calling user doesn't have view permission to the content",
+                    reason=e)
 
             raise
 
@@ -882,8 +882,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -1061,12 +1061,12 @@ class Confluence(AtlassianRestAPI):
                     raise ApiValueError(
                         "No space or no content type, or setup a wrong version "
                         "type set to content, or status param is not draft and "
-                        "status content is current"
-                    )(e)
+                        "status content is current",
+                        reason=e)
                 if e.response.status_code == 404:
                     raise ApiNotFoundError(
-                        "Can not find draft with current content"
-                    )(e)
+                        "Can not find draft with current content",
+                        reason=e)
 
                 raise
 
@@ -1120,12 +1120,12 @@ class Confluence(AtlassianRestAPI):
                     raise ApiValueError(
                         "No space or no content type, or setup a wrong version "
                         "type set to content, or status param is not draft and "
-                        "status content is current"
-                    )(e)
+                        "status content is current",
+                        reason=e)
                 if e.response.status_code == 404:
                     raise ApiNotFoundError(
-                        "Can not find draft with current content"
-                    )(e)
+                        "Can not find draft with current content",
+                        reason=e)
 
                 raise
 
@@ -1237,15 +1237,15 @@ class Confluence(AtlassianRestAPI):
                 raise ApiValueError(
                     "The given property has a different content id to the one in the "
                     "path, or the content already has a value with the given key, or "
-                    "the value is missing, or the value is too long"
-                )(e)
+                    "the value is missing, or the value is too long",
+                    reason=e)
             if e.response.status_code == 403:
                 raise ApiPermissionError(
                     "The user does not have permission to "
-                    "edit the content with the given id"
-                )(e)
+                    "edit the content with the given id",
+                    reason=e)
             if e.response.status_code == 413:
-                raise ApiValueError("The value is too long")(e)
+                raise ApiValueError("The value is too long", reason=e)
 
             raise
 
@@ -1267,8 +1267,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -1292,8 +1292,8 @@ class Confluence(AtlassianRestAPI):
                 raise ApiError(
                     "There is no content with the given id, or no property with the "
                     "given key, or the calling user does not have permission to view "
-                    "the content"
-                )(e)
+                    "the content",
+                    reason=e)
 
             raise
 
@@ -1314,8 +1314,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no content with the given id, "
-                    "or the calling user does not have permission to view the content"
-                )(e)
+                    "or the calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -1334,8 +1334,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view the content"
-                )(e)
+                    "The calling user does not have permission to view the content",
+                    reason=e)
 
             raise
 
@@ -1372,8 +1372,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 403:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view groups"
-                )(e)
+                    "The calling user does not have permission to view groups",
+                    reason=e)
 
             raise
 
@@ -1400,8 +1400,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 403:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view users"
-                )(e)
+                    "The calling user does not have permission to view users",
+                    reason=e)
 
             raise
 
@@ -1425,8 +1425,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no space with the given key, "
-                    "or the calling user does not have permission to view the space"
-                )(e)
+                    "or the calling user does not have permission to view the space",
+                    reason=e)
             raise
         return response
 
@@ -1466,8 +1466,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no space with the given key, "
-                    "or the calling user does not have permission to delete it"
-                )(e)
+                    "or the calling user does not have permission to delete it",
+                    reason=e)
 
             raise
 
@@ -1486,8 +1486,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no space with the given key, "
-                    "or the calling user does not have permission to view the space"
-                )(e)
+                    "or the calling user does not have permission to view the space",
+                    reason=e)
 
             raise
 
@@ -1511,12 +1511,12 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 403:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view users"
-                )(e)
+                    "The calling user does not have permission to view users",
+                    reason=e)
             if e.response.status_code == 404:
                 raise ApiNotFoundError(
-                    "The user with the given username or userkey does not exist"
-                )(e)
+                    "The user with the given username or userkey does not exist",
+                    reason=e)
 
             raise
 
@@ -1540,12 +1540,12 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 403:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to view users"
-                )(e)
+                    "The calling user does not have permission to view users",
+                    reason=e)
             if e.response.status_code == 404:
                 raise ApiNotFoundError(
-                    "The user with the given username or userkey does not exist"
-                )(e)
+                    "The user with the given username or userkey does not exist",
+                    reason=e)
 
             raise
 
@@ -1585,7 +1585,7 @@ class Confluence(AtlassianRestAPI):
             response = self.get('rest/api/search', params=params)
         except HTTPError as e:
             if e.response.status_code == 400:
-                raise ApiValueError("The query cannot be parsed")(e)
+                raise ApiValueError("The query cannot be parsed", reason=e)
 
             raise
 
@@ -1640,7 +1640,7 @@ class Confluence(AtlassianRestAPI):
             response = self.get(url, {})
         except HTTPError as e:
             if e.response.status_code == 400:
-                raise ApiValueError("The CQL is invalid or missing")(e)
+                raise ApiValueError("The CQL is invalid or missing", reason=e)
 
             raise
 
@@ -1710,8 +1710,8 @@ class Confluence(AtlassianRestAPI):
         except HTTPError as e:
             if e.response.status_code == 403:
                 raise ApiPermissionError(
-                    "The calling user does not have permission to use Confluence"
-                )(e)
+                    "The calling user does not have permission to use Confluence",
+                    reason=e)
 
             raise
 
@@ -1777,8 +1777,8 @@ class Confluence(AtlassianRestAPI):
                 # Raise ApiError as the documented reason is ambiguous
                 raise ApiError(
                     "There is no task with the given key, "
-                    "or the calling user does not have permission to view it"
-                )(e)
+                    "or the calling user does not have permission to view it",
+                    reason=e)
 
             raise
 

--- a/atlassian/errors.py
+++ b/atlassian/errors.py
@@ -2,7 +2,9 @@
 
 
 class ApiError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        self.reason = kwargs.get("reason")
+        super(ApiError, self).__init__(*args)
 
 
 class ApiNotFoundError(ApiError):

--- a/examples/confluence/confluence-nested-error.py
+++ b/examples/confluence/confluence-nested-error.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+from atlassian import Confluence
+from atlassian.confluence import ApiError
+
+""" This example shows a way to get the real reason for an exception"""
+try:
+    confluence = Confluence(
+        url='http://some_site_without_permission.com',
+        username='admin',
+        password='admin')
+    result = confluence.get_user_details_by_username(username="gonchik.tsymzhitov", expand="status")
+except ApiError as e:
+    print("FAILURE: {}, caused by {}".format(e, e.reason if e.reason is not None else "unknown reason"))
+else:
+    print(result)


### PR DESCRIPTION
Provide a new propety ApiError.reason to access the reason for an API error. Also provide an example file to show how to use it.

Note that it had not been fully tested under Python 2.

This closes #513 

Signed-off-by: Daven DU <davendu@tencent.com>