### PR TITLE
Confluence add_space_permission method

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1965,7 +1965,6 @@ class Confluence(AtlassianRestAPI):
         """
         url = 'rest/api/space/{}/permission'.format(space_key)
         data = {
-            'id': 2154,
             'subject': {'type': subject_type, 'identifier': subject_id},
             'operation': {'key': operation_key, 'target': operation_target},
             '_links': {}

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1964,7 +1964,12 @@ class Confluence(AtlassianRestAPI):
         :return: Current permissions of space
         """
         url = 'rest/api/space/{}/permission'.format(space_key)
-        data = {"id": 2154, "subject": {"type": subject_type, "identifier": subject_id }, "operation": {"key": operation_key, "target": operation_target}, "_links": {}}
+        data = {
+            'id': 2154,
+            'subject': {'type': subject_type, 'identifier': subject_id},
+            'operation': {'key': operation_key, 'target': operation_target},
+            '_links': {}
+        }
 
         return self.post(url, data=data, headers=self.experimental_headers)
 

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1952,6 +1952,22 @@ class Confluence(AtlassianRestAPI):
         data = {'name': username}
         return self.post(url, params=params, data=data)
 
+    def add_space_permissions(self, space_key, subject_type, subject_id, operation_key, operation_target):
+        """
+        Add permissions to a space
+
+        :param space_key: str
+        :param subject_type: str
+        :param subject_id: str
+        :param operation_key: str
+        :param operation_target: str
+        :return: Current permissions of space
+        """
+        url = 'rest/api/space/{}/permission'.format(space_key)
+        data = {"id": 2154, "subject": {"type": subject_type, "identifier": subject_id }, "operation": {"key": operation_key, "target": operation_target}, "_links": {}}
+
+        return self.post(url, data=data, headers=self.experimental_headers)
+
     def get_space_permissions(self, space_key):
         """
         The JSON-RPC APIs for Confluence are provided here to help you browse and discover APIs you have access to.


### PR DESCRIPTION
So, I copied other methods, and cribbed directly from the API example (https://developer.atlassian.com/cloud/confluence/rest/api-group-experimental/#api-api-space-spacekey-permission-post) to get this to work.

Caveat - There's no error handling, so if, for example, the permission already exists for space, you get an ugly (and uninformative):
> 400 Client Error: Bad Request for url

I was just happy I got it to work at all. :-}