### PR TITLE
Setting api_version=cloud when Cloud=true

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,9 @@ Here's a short example of how to create a Confluence page:
 
     print(status)
 
+(Note that for Confluence Cloud, some API calls are different, so you'll 
+want to add cloud=True to the Confluence() connection.)
+
 And here's another example of how to get issues from Jira using JQL Query:
 
 .. code-block:: python

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1965,7 +1965,6 @@ class Confluence(AtlassianRestAPI):
         """
         url = 'rest/api/space/{}/permission'.format(space_key)
         data = {
-            'id': 2154,
             'subject': {'type': subject_type, 'identifier': subject_id},
             'operation': {'key': operation_key, 'target': operation_target},
             '_links': {}

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1964,7 +1964,12 @@ class Confluence(AtlassianRestAPI):
         :return: Current permissions of space
         """
         url = 'rest/api/space/{}/permission'.format(space_key)
-        data = {"id": 2154, "subject": {"type": subject_type, "identifier": subject_id }, "operation": {"key": operation_key, "target": operation_target}, "_links": {}}
+        data = {
+            'id': 2154,
+            'subject': {'type': subject_type, 'identifier': subject_id},
+            'operation': {'key': operation_key, 'target': operation_target},
+            '_links': {}
+        }
 
         return self.post(url, data=data, headers=self.experimental_headers)
 

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1952,6 +1952,22 @@ class Confluence(AtlassianRestAPI):
         data = {'name': username}
         return self.post(url, params=params, data=data)
 
+    def add_space_permissions(self, space_key, subject_type, subject_id, operation_key, operation_target):
+        """
+        Add permissions to a space
+
+        :param space_key: str
+        :param subject_type: str
+        :param subject_id: str
+        :param operation_key: str
+        :param operation_target: str
+        :return: Current permissions of space
+        """
+        url = 'rest/api/space/{}/permission'.format(space_key)
+        data = {"id": 2154, "subject": {"type": subject_type, "identifier": subject_id }, "operation": {"key": operation_key, "target": operation_target}, "_links": {}}
+
+        return self.post(url, data=data, headers=self.experimental_headers)
+
     def get_space_permissions(self, space_key):
         """
         The JSON-RPC APIs for Confluence are provided here to help you browse and discover APIs you have access to.

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -28,6 +28,8 @@ class AtlassianRestAPI(object):
                 and '/wiki' not in url \
                 and self.__class__.__name__ in 'Confluence':
             url = self.url_joiner(url, '/wiki')
+        if (cloud == True):
+            api_version = 'cloud'
         self.url = url
         self.username = username
         self.password = password


### PR DESCRIPTION
I think this is a useful change, especially if Atlassian ever gets around to implementing https://jira.atlassian.com/browse/CLOUD-6999.

However the Documentation link in README.rst is showing version 1.15.3 (https://atlassian-python-api.readthedocs.io/) which doesn't include the section "To authenticate to the Atlassian Cloud APIs".

Can that be updated? It would probably be better if that was done before accepting this PR.

Thanks!