### PR TITLE
[Confluence] Return full response in Confluence.get_page_child_by_type

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -83,7 +83,7 @@ class Confluence(AtlassianRestAPI):
 
             raise
 
-        return response.get('results')
+        return response
 
     def get_child_title_list(self, page_id, type='page', start=None, limit=None):
         """


### PR DESCRIPTION
get_page_child_by_type should return whole response from Confluence, to be able to properly use pagination.