### PR TITLE
Fix cookie auth parameter in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,19 +133,19 @@ Or reuse cookie file:
 
     jira = Jira(
         url='http://localhost:8080',
-        cookie=cookie_dict)
+        cookies=cookie_dict)
 
     confluence = Confluence(
         url='http://localhost:8090',
-        cookie=cookie_dict)
+        cookies=cookie_dict)
 
     bitbucket = Bitbucket(
         url='http://localhost:7990',
-        cookie=cookie_dict)
+        cookies=cookie_dict)
 
     service_desk = ServiceDesk(
         url='http://localhost:8080',
-        cookie=cookie_dict)
+        cookies=cookie_dict)
 
 To authenticate to the Atlassian Cloud APIs:
 


### PR DESCRIPTION
The docs currently say to use the "cookie" parameter for cookie authentication, but the code actually uses the "cookies" parameter (plural).

See https://github.com/atlassian-api/atlassian-python-api/blob/23370dd1cbf7b1999131412096d5e1b4908098b8/atlassian/rest_client.py#L23-L25