### PR TITLE
feat: add xray rest api (server/data-center) support

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,6 +77,8 @@ All methods based on docs from: https://developer.atlassian.com/docs/
     - https://developer.atlassian.com/platform/marketplace/rest
 * Crowd:
     - https://developer.atlassian.com/server/crowd/crowd-rest-apis/
+* Xray:
+    - https://docs.getxray.app/display/XRAY/REST+API
 * Others:
     - https://developer.atlassian.com/server/jira/platform/oauth/
     - https://confluence.atlassian.com/cloud/api-tokens-938839638.html

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,20 @@ Example to get your requests:
     data = sd.get_my_customer_requests()
     print(data)
 
+Using Xray (Test Management tool for Jira):
+
+.. code-block:: python
+
+    from atlassian import Xray
+
+    xr = Xray(
+           url='http://localhost:7990',
+            username='admin',
+            password='admin')
+    
+    data = xr.get_tests('TEST-001')
+    print(data)
+
 If you want to see the response in pretty print format JSON. Feel free for use construction like:
 
 .. code-block:: python

--- a/atlassian/__init__.py
+++ b/atlassian/__init__.py
@@ -7,6 +7,7 @@ from .jira import Jira
 from .marketplace import MarketPlace
 from .portfolio import Portfolio
 from .service_desk import ServiceDesk
+from .xray import Xray
 
 __all__ = [
     'Confluence',
@@ -17,5 +18,6 @@ __all__ = [
     'Stash',
     'Crowd',
     'ServiceDesk',
-    'MarketPlace'
+    'MarketPlace',
+    'Xray'
 ]

--- a/atlassian/xray.py
+++ b/atlassian/xray.py
@@ -1,0 +1,383 @@
+# coding=utf-8
+import logging
+import re
+
+from .rest_client import AtlassianRestAPI
+
+log = logging.getLogger(__name__)
+
+
+class Xray(AtlassianRestAPI):
+
+    def __init__(self, *args, **kwargs):
+        super(Xray, self).__init__(*args, **kwargs)
+
+    # Tests API
+    def get_tests(self, test_keys):
+        """
+        Retrieve information about the provided tests.
+        :param test_keys: list of tests (eg. `['TEST-001', 'TEST-002']`) to retrieve.
+        :return: Returns the retrieved tests.
+        """
+        url = 'rest/raven/1.0/api/test/?keys={0}'.format(';'.join(test_keys))
+        return self.get(url)
+
+    def get_test_statuses(self):
+        """
+        Retrieve a list of all Test Statuses available in Xray sorted by rank.
+        :return: Returns the test statuses.
+        """
+        url = 'rest/raven/1.0/api/settings/teststatuses'
+        return self.get(url)
+
+    def get_test_runs(self, test_key):
+        """
+        Retrieve test runs of a test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Returns the exported test runs.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/testruns'.format(test_key)
+        return self.get(url)
+
+    def get_test_runs_with_environment(self, test_key, test_environments):
+        # TODO
+        """
+        Retrieve test runs of a test filtered by tests environments.
+        :param test_key: Test key (eg. 'TEST-001').
+        :param test_environments: Test execution environments separated by ','.
+        :return: Returns the exported test runs.
+        """
+        env = '?testEnvironments={0}'.format(','.join([re.escape(env) for env in test_environments]))
+        url = 'rest/raven/1.0/api/test/{0}/testruns{1}'.format(test_key, env)
+        return self.get(url)
+
+    def get_test_preconditions(self, test_key):
+        """
+        Retrieve pre-conditions of a test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Returns the test pre-conditions of a given test.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/preconditions'.format(test_key)
+        return self.get(url)
+        
+    def get_test_sets(self, test_key):
+        """
+        Retrieve test sets associated with a test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Returns the exported test sets.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/testsets'.format(test_key)
+        return self.get(url)
+
+    def get_test_executions(self, test_key):
+        """
+        Retrieve test executions of a test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Returns the exported test executions.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/testexecutions'.format(test_key)
+        return self.get(url)
+
+    def get_test_plans(self, test_key):
+        """
+        Retrieve test plans associated with a test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Returns the exported test plans.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/testplans'.format(test_key)
+        return self.get(url)
+
+    # Test Steps API
+    def get_test_step_statuses(self):
+        """
+        Retrieve the test step statuses available in Xray sorted by rank.
+        :return: Returns the test step statuses available in Xray sorted by rank.
+        """
+        url = 'rest/raven/1.0/api/settings/teststepstatuses'
+        return self.get(url)
+
+    def get_test_step(self, test_key, test_step_id):
+        """
+        Retrieve the specified test step of a given test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :param test_step_id: ID of the test step.
+        :return: Return the test step with the given id.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/step/{1}'.format(test_key, test_step_id)
+        return self.get(url)
+
+    def get_test_steps(self, test_key):
+        """
+        Retrieve the test steps of a given test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :return: Return the test steps of a given test.
+        """
+        url = 'rest/raven/1.0/api/test/{0}/step'.format(test_key)
+        return self.get(url)
+
+    def create_test_step(self, test_key, step, data, result):
+        """
+        Create a new test steps for a given test.
+        NOTE: attachments are currently not supported!
+        :param test_key: Test key (eg. 'TEST-001').
+        :param step: Test Step name (eg. 'Example step').
+        :param data: Test Step data (eg. 'Example data').
+        :param results: Test Step results (eg. 'Example results').
+        :return: 
+        """
+        create = {'step': step, 'data': data, 'result': result, 'attachments': []}
+        url = 'rest/raven/1.0/api/test/{0}/step'.format(test_key)
+        return self.put(url, create)
+
+    def update_test_step(self, test_key, test_step_id, step, data, result):
+        """
+        Update the specified test steps for a given test.
+        NOTE: attachments are currently not supported!
+        :param test_key: Test key (eg. 'TEST-001').
+        :param test_step_id: ID of the test step.
+        :param step: Test Step name (eg. 'Example step').
+        :param data: Test Step data (eg. 'Example data').
+        :param results: Test Step results (eg. 'Example results').
+        :return:
+        """
+        update = {'step': step, 'data': data, 'result': result, 'attachments': {'add': [], 'remove': []}}
+        url = 'rest/raven/1.0/api/test/{0}/step/{1}'.format(test_key, test_step_id)
+        return self.post(url, update)
+
+    def delete_test_step(self, test_key, test_step_id):
+        """
+        Remove the specified test steps from a given test.
+        :param test_key: Test key (eg. 'TEST-001').
+        :param test_step_id: ID of the test step.
+        :return:
+        """
+        url = 'rest/raven/1.0/api/test/{0}/step/{1}'.format(test_key, test_step_id)
+        return self.delete(url)
+
+    # Pre-Conditions API
+    def get_tests_with_precondition(self, precondition_key):
+        """
+        Retrieve the tests associated with the given pre-condition.
+        :param precondition_key: Precondition key (eg. 'TEST-001').
+        :return: Return a list of the test associated with the pre-condition.
+        """
+        url = 'rest/raven/1.0/api/precondition/{0}/test'.format(precondition_key)
+        return self.get(url)
+
+    def update_precondition(self, precondition_key, add=[], remove=[]):
+        """
+        Associate tests with the given pre-condition.
+        :param precondition_key: Precondition key (eg. 'TEST-001').
+        :param add: OPTIONAL List of Test Keys to associate with the pre-condition (eg. ['TEST-002', 'TEST-003'])
+        :param add: OPTIONAL List of Test Keys no longer associate with the pre-condition (eg. ['TEST-004', 'TEST-005'])
+        :return:
+        """
+        update = {'add': add, 'remove': remove}
+        url = 'rest/raven/1.0/api/precondition/{0}/test'.format(precondition_key)
+        return self.post(url, update)
+
+    def delete_test_from_precondition(self, precondition_key, test_key):
+        """
+        Remove association of the specified tests from the given pre-condition.
+        :param precondition_key: Precondition key (eg. 'TEST-001').
+        :param test_key: Test Key which should no longer be associate with the pre-condition (eg. 'TEST-100')
+        :return:
+        """
+        url = 'rest/raven/1.0/api/precondition/{0}/test/{1}'.format(precondition_key, test_key)
+        return self.delete(url)
+
+    # Test Set API
+    def get_tests_with_test_set(self, test_set_key):
+        """
+        Retrieve the tests associated with the given test set.
+        :param test_set_key: Test set key (eg. 'SET-001').
+        :return: Return a list of the test associated with the test set.
+        """
+        url = 'rest/raven/1.0/api/testset/{0}/test'.format(test_set_key)
+        return self.get(url)
+
+    def update_test_set(self, test_set_key, add=[], remove=[]):
+        """
+        Associate tests with the given test set.
+        :param test_set_key: Test set key (eg. 'SET-001').
+        :param add: OPTIONAL List of Test Keys to associate with the test set (eg. ['TEST-002', 'TEST-003'])
+        :param add: OPTIONAL List of Test Keys no longer associate with the test set (eg. ['TEST-004', 'TEST-005'])
+        :return:
+        """
+        update = {'add': add, 'remove': remove}
+        url = 'rest/raven/1.0/api/testset/{0}/test'.format(test_set_key)
+        return self.post(url, update)
+
+    def delete_test_from_test_set(self, test_set_key, test_key):
+        """
+        Remove association of the specified tests from the given test set.
+        :param test_set_key: Test set key (eg. 'SET-001').
+        :param test_key: Test Key which should no longer be associate with the test set (eg. 'TEST-100')
+        :return:
+        """
+        url = 'rest/raven/1.0/api/testset/{0}/test/{1}'.format(test_set_key, test_key)
+        return self.delete(url)
+
+    # Test Plans API
+    def get_tests_with_test_plan(self, test_plan_key):
+        """
+        Retrieve the tests associated with the given test plan.
+        :param test_plan_key: Test set key (eg. 'PLAN-001').
+        :return: Return a list of the test associated with the test plan.
+        """
+        url = 'rest/raven/1.0/api/testplan/{0}/test'.format(test_plan_key)
+        return self.get(url)
+
+    def update_test_plan(self, test_plan_key, add=[], remove=[]):
+        """
+        Associate tests with the given test plan.
+        :param test_plan_key: Test plan key (eg. 'PLAN-001').
+        :param add: OPTIONAL List of Test Keys to associate with the test plan (eg. ['TEST-002', 'TEST-003'])
+        :param add: OPTIONAL List of Test Keys no longer associate with the test plan (eg. ['TEST-004', 'TEST-005'])
+        :return:
+        """
+        update = {'add': add, 'remove': remove}
+        url = 'rest/raven/1.0/api/testplan/{0}/test'.format(test_plan_key)
+        return self.post(url, update)
+
+    def delete_test_from_test_plan(self, test_plan_key, test_key):
+        """
+        Remove association of the specified tests from the given test plan.
+        :param test_plan_key: Test plan key (eg. 'PLAN-001').
+        :param test_key: Test Key which should no longer be associate with the test plan (eg. 'TEST-100')
+        :return:
+        """
+        url = 'rest/raven/1.0/api/testplan/{0}/test/{1}'.format(test_plan_key, test_key)
+        return self.delete(url)
+
+    # Test Executions API
+    def get_tests_with_test_execution(self, test_exec_key):
+        """
+        Retrieve the tests associated with the given test execution.
+        :param test_exec_key: Test execution key (eg. 'EXEC-001').
+        :return: Return a list of the test associated with the test execution.
+        """
+        url = 'rest/raven/1.0/api/testexec/{0}/test'.format(test_exec_key)
+        return self.get(url)
+
+    def update_test_execution(self, test_exec_key, add=[], remove=[]):
+        """
+        Associate tests with the given test execution.
+        :param test_exec_key: Test execution key (eg. 'EXEC-001').
+        :param add: OPTIONAL List of Test Keys to associate with the test execution (eg. ['TEST-002', 'TEST-003'])
+        :param add: OPTIONAL List of Test Keys no longer associate with the test execution (eg. ['TEST-004', 'TEST-005'])
+        :return:
+        """
+        update = {'add': add, 'remove': remove}
+        url = 'rest/raven/1.0/api/testexec/{0}/test'.format(test_exec_key)
+        return self.post(url, update)
+
+    def delete_test_from_test_execution(self, test_exec_key, test_key):
+        """
+        Remove association of the specified tests from the given test execution.
+        :param test_exec_key: Test execution key (eg. 'EXEC-001').
+        :param test_key: Test Key which should no longer be associate with the test execution (eg. 'TEST-100')
+        :return:
+        """
+        url = 'rest/raven/1.0/api/testexec/{0}/test/{1}'.format(test_exec_key, test_key)
+        return self.delete(url)
+
+    # Test Runs API
+    def get_test_run(self, test_run_id):
+        """
+        Retrieve detailed information about the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns detailed information about the test run.
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}'.format(test_run_id)
+        return self.get(url)
+
+    def get_test_run_assignee(self, test_run_id):
+        """
+        Retrieve the assignee for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns the assignee for the given test run
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}/assignee'.format(test_run_id)
+        return self.get(url)
+
+    def update_test_run_assignee(self, test_run_id, assignee):
+        """
+        Update the assignee for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :param assignee: Assignee id (eg. 'bob')
+        :return: 
+        """
+        update = {'assignee': assignee}
+        url = 'rest/raven/1.0/api/testrun/{0}'.format(test_run_id)
+        return self.put(url, update)
+
+    def get_test_run_status(self, test_run_id):
+        """
+        Retrieve the status for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns the status for the given test run
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}/status'.format(test_run_id)
+        return self.get(url)
+
+    def update_test_run_status(self, test_run_id, status):
+        """
+        Update the status for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :param assignee: Assignee id (eg. 'PASS')
+        :return: 
+        """
+        update = {'status': status}
+        url = 'rest/raven/1.0/api/testrun/{0}'.format(test_run_id)
+        return self.put(url, update)
+    
+    def get_test_run_defects(self, test_run_id):
+        """
+        Retrieve the defects for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns a list of defects for the given test run
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}/defect'.format(test_run_id)
+        return self.get(url)
+
+    def update_test_run_defects(self, test_run_id, add=[], remove=[]):
+        """
+        Update the defects associated with the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :param add: OPTIONAL List of defects to associate to the test run (eg. ['BUG-001', 'BUG-002'])
+        :param remove: OPTIONAL List of defects which no longer need to be associated to the test run (eg. ['BUG-003'])
+        :return: 
+        """
+        update = {'defects': {'add': add, 'remove': remove}}
+        url = 'rest/raven/1.0/api/testrun/{0}'.format(test_run_id)
+        return self.put(url, update)
+
+    def get_test_run_comment(self, test_run_id):
+        """
+        Retrieve the comment for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns the comment for the given test run
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}/comment'.format(test_run_id)
+        return self.get(url)
+
+    def update_test_run_comment(self, test_run_id, comment):
+        """
+        Update the comment for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :param comment: Comment (eg. 'Test needs to be reworked')
+        :return: 
+        """
+        update = {'comment': comment}
+        url = 'rest/raven/1.0/api/testrun/{0}'.format(test_run_id)
+        return self.put(url, update)
+
+    def get_test_run_steps(self, test_run_id):
+        """
+        Retrieve the steps for the given test run.
+        :param test_run_id: ID of the test run (eg. 100).
+        :return: Returns the steps for the given test run
+        """
+        url = 'rest/raven/1.0/api/testrun/{0}/step'.format(test_run_id)
+        return self.get(url)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Add a connection:
     from atlassian import Confluence
     from atlassian import Bitbucket
     from atlassian import ServiceDesk
+    from atlassian import Xray
 
     jira = Jira(
         url='http://localhost:8080',
@@ -39,6 +40,11 @@ Add a connection:
         password='admin')
 
     service_desk = ServiceDesk(
+        url='http://localhost:8080',
+        username='admin',
+        password='admin')
+
+    xray = Xray(
         url='http://localhost:8080',
         username='admin',
         password='admin')
@@ -55,6 +61,7 @@ Add a connection using key/cert based authentication:
     from atlassian import Confluence
     from atlassian import Bitbucket
     from atlassian import ServiceDesk
+    from atlassian import Xray
 
     jira = Jira(
         url='http://localhost:8080',
@@ -72,6 +79,11 @@ Add a connection using key/cert based authentication:
         cert='/path/to/cert')
 
     service_desk = ServiceDesk(
+        url='http://localhost:8080',
+        key='/path/to/key',
+        cert='/path/to/cert')
+
+    xray = Xray(
         url='http://localhost:8080',
         key='/path/to/key',
         cert='/path/to/cert')
@@ -102,6 +114,10 @@ Alternatively OAuth can be used:
         url='http://localhost:8080',
         oauth=oauth_dict)
 
+    xray = Xray(
+        url='http://localhost:8080',
+        oauth=oauth_dict)
+
 Or Kerberos *(installation with kerberos extra necessary)*:
 
 .. code-block:: python
@@ -121,6 +137,10 @@ Or Kerberos *(installation with kerberos extra necessary)*:
         kerberos=kerberos_service)
 
     service_desk = ServiceDesk(
+        url='http://localhost:8080',
+        kerberos=kerberos_service)
+
+    xray = Xray(
         url='http://localhost:8080',
         kerberos=kerberos_service)
 
@@ -144,6 +164,10 @@ Or reuse cookie file:
         cookies=cookie_dict)
 
     service_desk = ServiceDesk(
+        url='http://localhost:8080',
+        cookies=cookie_dict)
+
+    xray = Xray(
         url='http://localhost:8080',
         cookies=cookie_dict)
 
@@ -177,8 +201,6 @@ To authenticate to the Atlassian Cloud APIs:
         password=jira_api_token,
         cloud=True)
 
-
-
 .. toctree::
    :maxdepth: 2
 
@@ -187,6 +209,7 @@ To authenticate to the Atlassian Cloud APIs:
    bitbucket
    bamboo
    service_desk
+   xray
 
 .. |Build Status| image:: https://travis-ci.org/atlassian-api/atlassian-python-api.svg?branch=master
    :target: https://pypi.python.org/pypi/atlassian-python-api

--- a/docs/xray.rst
+++ b/docs/xray.rst
@@ -1,0 +1,147 @@
+Xray module
+===========
+
+.. NOTE: The Xray module only support the Server + Data Center edition of the Xray Jira plugin!
+
+Manage Test
+-----------
+
+.. code-block:: python
+
+    # Retrieve information about the provided tests
+    xray.get_tests(['TEST-001', 'TEST-002'])
+
+    # Retrieve a list of all Test Statuses available in Xray sorted by rank
+    xray.get_test_statuses()
+
+    # Retrieve test runs of a test
+    xray.get_test_runs('TEST-001')
+
+    # Retrieve test runs of a test filtered by tests environments
+    xray.get_test_runs_with_environment('TEST-001', 'Android,iOS')
+
+    # Retrieve pre-conditions of a test
+    xray.get_test_preconditions('TEST-001')
+
+    # Retrieve test sets associated with a test
+    xray.get_test_sets('TEST-001')
+    
+    # Retrieve test executions of a test
+    xray.get_test_executions('TEST-001')
+
+    # Retrieve test plans associated with a test
+    xray.get_test_plans('TEST-001')
+
+Manage Test Steps
+-----------------
+
+.. code-block:: python
+
+    # Retrieve the test step statuses available in Xray sorted by rank
+    xray.get_test_step_statuses()
+
+    # Retrieve the specified test step of a given test
+    xray.get_test_step('TEST-001', 'STEP-001')
+
+    # Retrieve the test steps of a given test
+    xray.get_test_steps('TEST-001')
+
+    # Create a new test steps for a given test
+    xray.create_test_step('TEST-001', 'Example Test Step', 'Example Test Data', 'Example Test Result')
+
+    # Update the specified test steps for a given test
+    xray.update_test_step('TEST-001', 100, 'Updated Test Step', 'Updated Test Data', 'Updated Test Result')
+
+    # Remove the specified test steps from a given test
+    xray.delete_test_step('TEST-001', 100)
+
+Manage Pre-conditions
+---------------------
+
+.. code-block:: python
+
+    # Retrieve the tests associated with the given pre-condition
+    xray.get_tests_with_precondition('PREC-001')
+
+    # Associate tests with the given pre-condition 
+    xray.update_precondition('PREC-001', add=['TEST-001','TEST-002'], remove=['TEST-003'])
+
+    # Remove association of the specified tests from the given pre-condition
+    xray.delete_test_from_precondition('PREC-001', 'TEST-003')
+
+Manage Test sets
+----------------
+
+.. code-block:: python
+
+    # Retrieve the tests associated with the given test set
+    xray.get_tests_with_test_set('SET-001')
+
+    # Associate tests with the given test set
+    xray.update_test_set('SET-001',add=['TEST-001','TEST-002'], remove=['TEST-003'])
+
+    #  Remove association of the specified tests from the given test set
+    xray.delete_test_from_test_set('SET-001', 'TEST-003')
+
+Manage Test plans
+-----------------
+
+.. code-block:: python
+    
+    # Retrieve the tests associated with the given test plan
+    xray.get_tests_with_test_plan('PLAN-001')
+
+    # Associate tests with the given test plan
+    xray.update_test_plan('PLAN-001', add=['TEST-001', 'TEST-002'], remove=['TEST-003'])
+
+    # Remove association of the specified tests from the given test plan
+    xray.delete_test_from_test_plan('PLAN-001', 'TEST-001'):
+
+Manage Test Executions
+----------------------
+
+.. code-block:: python
+
+    # Retrieve the tests associated with the given test execution
+    xray.get_tests_with_test_execution('EXEC-001')
+
+    # Associate tests with the given test execution
+    xray.update_test_execution('EXEC-001', add=['TEST-001', 'TEST-002'], remove=['TEST-003'])
+
+    # Remove association of the specified tests from the given test execution
+    xray.delete_test_from_test_execution('EXEC-001', 'TEST-001')
+
+Manage Test Runs
+----------------
+
+.. code-block:: python
+
+    # Retrieve detailed information about the given test run
+    xray.get_test_run(100)
+
+    # Retrieve the assignee for the given test run.
+    xray.get_test_run_assignee(100)      
+
+    # Update the assignee for the given test run
+    xray.update_test_run_assignee(100, 'bob')
+
+    # Retrieve the status for the given test run
+    xray.get_test_run_status(100)
+
+    # Update the status for the given test run
+    xray.update_test_run_status(100, 'PASS')
+    
+    # Retrieve the defects for the given test run
+    xray.get_test_run_defects(100)
+
+    # Update the defects associated with the given test run
+    xray.update_test_run_defects(100, add=['BUG-001', 'BUG-002'], remove=['BUG-003'])
+
+    # Retrieve the comment for the given test run
+    xray.get_test_run_comment(100)
+
+    # Update the comment for the given test run
+    xray.update_test_run_comment(100, 'Test needs to be reworked')
+
+    # Retrieve the steps for the given test run
+    xray.get_test_run_steps(100)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,5 @@
 # coding: utf8
-from atlassian import Jira, Confluence, Bitbucket, Bamboo, Crowd, ServiceDesk
+from atlassian import Jira, Confluence, Bitbucket, Bamboo, Crowd, ServiceDesk, Xray
 import os
 
 BAMBOO_URL = os.environ.get('BAMBOO_URL', 'http://localhost:8085')
@@ -7,6 +7,7 @@ JIRA_URL = os.environ.get('BAMBOO_URL', 'http://localhost:8080')
 CONFLUENCE_URL = os.environ.get('BAMBOO_URL', 'http://localhost:8090')
 STASH_URL = os.environ.get('BAMBOO_URL', 'http://localhost:7990')
 SERVICE_DESK_URL = os.environ.get('SERVICE_DESK_URL', 'http://localhost:8080')
+XRAY_URL = os.environ.get('XRAY_URL', 'http://localhost:8080')
 
 CROWD_URL = os.environ.get('CROWD_URL', 'http://localhost:8095/crowd')
 CROWD_APPLICATION = os.environ.get('CROWD_APPLICATION', 'bamboo')
@@ -55,6 +56,13 @@ class TestBasic(object):
     def test_init_service_desk(self):
         service_desk = ServiceDesk(
             url=SERVICE_DESK_URL,
+            username=ATLASSIAN_USER,
+            password=ATLASSIAN_PASSWORD
+        )
+
+    def test_init_xray(self):
+        xray = Xray(
+            url=XRAY_URL,
             username=ATLASSIAN_USER,
             password=ATLASSIAN_PASSWORD
         )


### PR DESCRIPTION
Add support for v1.0 of the Xray REST api for Server and Data-Center. 
Xray is a Jira plugin which provides Test Management support. I use the REST api for test automation (+feedback) from CI.

NOTE:
* As of now, v2.0 does not cover all functionality provided in the initial version, mainly related to test automation (eg. import of test executions).
* The REST api of Xray for Jira Cloud differs from Jira Server/DC.