### PR TITLE
Set correct header for attach_temporary_file for ServiceDesk

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -432,7 +432,10 @@ class ServiceDesk(AtlassianRestAPI):
         url = 'rest/servicedeskapi/servicedesk/{}/attachTemporaryFile'.format(service_desk_id)
 
         with open(filename, 'rb') as file:
-            result = self.post(path=url, headers=self.experimental_headers,
+            headers = {
+                        'X-Atlassian-Token': 'no-check',
+                        'X-ExperimentalApi': 'opt-in'}
+            result = self.post(path=url, headers=headers,
                                files={'file': file}).get('temporaryAttachments')
             temp_attachment_id = result[0].get('temporaryAttachmentId')
 


### PR DESCRIPTION
Fixes: #557 

More like a hotfix...
https://docs.atlassian.com/jira-servicedesk/REST/3.6.2/#servicedeskapi/servicedesk/{serviceDeskId}/attachTemporaryFile-attachTemporaryFile
`This resource expects a multipart post`. 
The experimental headers are however set to `application/json`.