### PR TITLE
[RestClient] Cleanup base class and fix init order in derived class

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -10,11 +10,12 @@ log = logging.getLogger(__name__)
 class Bitbucket(AtlassianRestAPI):
     bulk_headers = {"Content-Type": "application/vnd.atl.bitbucket.bulk+json"}
 
-    def __init__(self, *args, **kwargs):
-        super(Bitbucket, self).__init__(*args, **kwargs)
-        url = kwargs.pop('url', False)
-        if url and 'bitbucket.org' in url:
-            self.cloud = True
+    def __init__(self, **kwargs):
+        if (not 'cloud' in kwargs
+            and 'url' in kwargs
+            and ('bitbucket.org' in kwargs['url']) ):
+            kwargs['cloud'] = True
+        super(Bitbucket, self).__init__(**kwargs)
 
     def project_list(self, limit=None):
         """

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -10,12 +10,11 @@ log = logging.getLogger(__name__)
 class Bitbucket(AtlassianRestAPI):
     bulk_headers = {"Content-Type": "application/vnd.atl.bitbucket.bulk+json"}
 
-    def __init__(self, **kwargs):
+    def __init__(self, url, *args, **kwargs):
         if (not 'cloud' in kwargs
-            and 'url' in kwargs
-            and ('bitbucket.org' in kwargs['url']) ):
+            and ('bitbucket.org' in url) ):
             kwargs['cloud'] = True
-        super(Bitbucket, self).__init__(**kwargs)
+        super(Bitbucket, self).__init__(url, *args, **kwargs)
 
     def project_list(self, limit=None):
         """

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -30,15 +30,13 @@ class Confluence(AtlassianRestAPI):
         ".svg": "image/svg+xml"
     }
 
-    def __init__(self, **kwargs):
-        if ('url' in kwargs
-            and kwargs['url']
-            and ('atlassian.net' in kwargs['url'] or 'jira.com' in kwargs['url'])
-            and ('/wiki' not in kwargs['url']) ):
-            kwargs['url'] = AtlassianRestAPI.url_joiner(kwargs['url'], '/wiki')
+    def __init__(self, url, *args, **kwargs):
+        if (('atlassian.net' in url or 'jira.com' in url)
+            and ('/wiki' not in url) ):
+            url = AtlassianRestAPI.url_joiner(url, '/wiki')
             if not 'cloud' in kwargs:
                 kwargs['cloud'] = True
-        super(Confluence, self).__init__(**kwargs)
+        super(Confluence, self).__init__(url, *args, **kwargs)
 
 
     @staticmethod

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -30,6 +30,17 @@ class Confluence(AtlassianRestAPI):
         ".svg": "image/svg+xml"
     }
 
+    def __init__(self, **kwargs):
+        if ('url' in kwargs
+            and kwargs['url']
+            and ('atlassian.net' in kwargs['url'] or 'jira.com' in kwargs['url'])
+            and ('/wiki' not in kwargs['url']) ):
+            kwargs['url'] = AtlassianRestAPI.url_joiner(kwargs['url'], '/wiki')
+            if not 'cloud' in kwargs:
+                kwargs['cloud'] = True
+        super(Confluence, self).__init__(**kwargs)
+
+
     @staticmethod
     def _create_body(body, representation):
         if representation not in ['editor', 'export_view', 'view', 'storage', 'wiki']:

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -26,10 +26,6 @@ class AtlassianRestAPI(object):
     def __init__(self, url, username=None, password=None, timeout=60, api_root='rest/api', api_version='latest',
                  verify_ssl=True, session=None, oauth=None, cookies=None, advanced_mode=None, kerberos=None,
                  cloud=False, proxies=None):
-        if ('atlassian.net' in url or 'jira.com' in url) \
-                and '/wiki' not in url \
-                and self.__class__.__name__ in 'Confluence':
-            url = self.url_joiner(url, '/wiki')
         self.url = url
         self.username = username
         self.password = password


### PR DESCRIPTION
Add `__init__` to Confluence and move specific code from `rest_client.py` to this new function.
Change order in `__init__` of Bitbucket to prevent errors if `__init__`of `AtlassianRestAPI` is dependent from the `cloud` flag.