### PR TITLE
[Bitbucket] Enforce PR limit when using server

### DIFF
--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -801,7 +801,7 @@ class Bitbucket(AtlassianRestAPI):
                 pr_list.extend(response.get("values", []))
 
         else:
-            while not response.get('isLastPage'):
+            while not response.get('isLastPage') and len(pr_list) < limit:
                 start = response.get('nextPageStart')
                 params['start'] = start
                 response = self.get(url, params=params)


### PR DESCRIPTION
When pulling PRs from bitbucket server, the limit url parameter doesn't
seem to be beeing heeded. This change allows the library to prevent too
many PRs from being returned to the client.

In my particular version of bitbucket: Atlassian Bitbucket v5.14.1 
When calling this function I was getting back, even when called with a limit explicitly set. This change allows the client to help the server in the event the server returns more data than we want.
