### PR TITLE
[BitBucket]: Refactor url handling.

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -120,8 +120,12 @@ class AtlassianRestAPI(object):
             url=url)
         log.log(level=level, msg=message)
 
-    def resource_url(self, resource):
-        return '/'.join([self.api_root, self.api_version, resource])
+    def resource_url(self, resource, api_root, api_version):
+        if api_root is None:
+            api_root = self.api_root
+        if api_version is None:
+            api_version = self.api_version
+        return '/'.join([api_root, api_version, resource])
 
     @staticmethod
     def url_joiner(url, path, trailing=None):


### PR DESCRIPTION
- Refactor API endpoints to reuse the common leading parts.
- Refactor get call for paging:
  - Move code for paging to a separate function and reuse it in the paged endpoints.
  - In advanced mode the raw data is returned,
  - If limit is given the next page is read until the given limit.
  - If limit is None the whole list is retrieved.

The functions are a reordered according to the endpoint url.