### PR TITLE
[Bitbucket] Fix wrong URLs after refactoring

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -1436,7 +1436,7 @@ class Bitbucket(BitbucketBase):
         self, project_key, repository_slug, pull_request_id, comment_id
     ):
         url = "{}/{}".format(
-            self._url_pull_request(project_key, repository_slug, pull_request_id),
+            self._url_pull_request_comments(project_key, repository_slug, pull_request_id),
             comment_id,
         )
         return url


### PR DESCRIPTION
The commit a9c6159bcf98992a4bb892a2fb4ad8090c3bd836 changed the URL handling. The non default API roots are changed wrong. 
I've searched in the old implementation all endpoint not matching the default root `rest/api` with the regular expression `['"]\/?rest\/(?!api)` and checked the new implementation.

I think that the old implementation of `get_project_condition` used the wrong endpoint. According to the [documentation](https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-default-reviewers-rest.html#idm52264901504) the endpoint for a specific condition is `/rest/default-reviewers/1.0/projects/{projectKey}/condition/{id}` and not `.../conditions/{id}`.

closes #619 