### PR TITLE
[Tests] Remove/Replace references to Travis CI.

### DIFF
--- a/.github/bump_version
+++ b/.github/bump_version
@@ -24,8 +24,8 @@ increase=${2:patch}
 
 function autoversion(){
 
-    if [ -n "${TRAVIS_BUILD_NUMBER+x}" ]; then
-        BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}"
+    if [ -n "${GITHUB_RUN_NUMBER+x}" ]; then
+        BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
     else
         BUILD_NUMBER="0"  # In the developer machine, this will build x.y.z.dev0
     fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Docker
       run: |
+        .github/bump_version ./ minor > atlassian/VERSION
         make docker-qa PYTHON_VERSION=${{matrix.python-version}}
     

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,10 +134,10 @@ In addition to all the contributors we would like to thank to these companies:
 
 * Atlassian_ for developing such a powerful ecosystem.
 * JetBrains_ for providing us with free licenses of PyCharm_
-* Travis_ for hosting our continuous integration
+* GitHub_ for hosting our repository and continuous integration
 * Insomnia_ for providing the human rest client easy to test the methods
 .. _Atlassian: https://www.atlassian.com/
 .. _JetBrains: http://www.jetbrains.com
 .. _PyCharm: http://www.jetbrains.com/pycharm/
-.. _Travis: https://travis-ci.org/
+.. _GitHub: https://github.com/
 .. _Insomnia: https://insomnia.rest/

--- a/README.rst
+++ b/README.rst
@@ -131,8 +131,8 @@ Let's fork and provide your changes :)
 See the `Contribution Guidelines for this project`_ for details on how to make changes to this library.
 
 .. _Contribution Guidelines for this project: CONTRIBUTING.rst
-.. |Build Status| image:: https://travis-ci.org/atlassian-api/atlassian-python-api.svg?branch=master
-   :target: https://pypi.python.org/pypi/atlassian-python-api
+.. |Build Status| image:: https://github.com/atlassian-api/atlassian-python-api/workflows/Test/badge.svg?branch=master
+   :target: https://github.com/atlassian-api/atlassian-python-api/actions?query=workflow%3ATest+branch%3Amaster
    :alt: Build status
 .. |PyPI version| image:: https://badge.fury.io/py/atlassian-python-api.svg
    :target: https://badge.fury.io/py/atlassian-python-api
@@ -160,11 +160,11 @@ In addition to all the contributors we would like to thank these vendors:
 * Atlassian_ for developing such a powerful ecosystem.
 * JetBrains_ for providing us with free licenses of PyCharm_
 * Microsoft_ for providing us with free licenses of VSCode_
-* Travis_ for hosting our continuous integration
+* GitHub_ for hosting our repository and continuous integration
 
 .. _Atlassian: https://www.atlassian.com/
 .. _JetBrains: http://www.jetbrains.com
 .. _PyCharm: http://www.jetbrains.com/pycharm/
-.. _Travis: https://travis-ci.org/
+.. _GitHub: https://github.com/
 .. _Microsoft: https://github.com/Microsoft/vscode/
 .. _VSCode: https://code.visualstudio.com/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -210,7 +210,7 @@ To authenticate to the Atlassian Cloud APIs:
    service_desk
    xray
 
-.. |Build Status| image:: https://travis-ci.org/atlassian-api/atlassian-python-api.svg?branch=master
+.. |Build Status| image:: https://github.com/atlassian-api/atlassian-python-api/workflows/Test/badge.svg?branch=master
    :target: https://pypi.python.org/pypi/atlassian-python-api
    :alt: Build status
 .. |PyPI version| image:: https://badge.fury.io/py/atlassian-python-api.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.flake8]
 max-line-length = 120
-exclude = '.tox,.travis,docs'
+exclude = '.tox,docs'
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
- Update documentation.
- Switch status badge to GitHub.
- Call bump_version in GitHub actions.