### PR TITLE
[ServiceDesk] Added the "Create request type" method available on the REST API "requestType" endpoint

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -681,3 +681,36 @@ class ServiceDesk(AtlassianRestAPI):
         ).headers["upm-token"]
         url = "rest/plugins/1.0/?token={upm_token}".format(upm_token=upm_token)
         return self.post(url, files=files, headers=self.no_check_headers)
+    
+    def create_request_type(
+        self,
+        service_desk_id,
+        request_type_id,
+        request_name,
+        request_description,
+        request_help_text,
+    ):
+        """
+        Creating a request type
+        :param service_desk_id: str
+        :param request_name: str
+        :param request_description: str
+        :param request_help_test: str
+        """
+        log.warning("Creating request type...")
+        data = {
+            "issueTypeId": request_type_id,
+            "name": request_name,
+            "description": request_description,
+            "helpText": request_help_text,
+        }
+
+        param_map = {"headers": self.experimental_headers}
+
+        if isinstance(values_dict, dict):
+            param_map["json"] = data
+        elif isinstance(values_dict, str):
+            param_map["data"] = data
+            
+        url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)
+        return self.post(url, **param_map)

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -702,7 +702,7 @@ class ServiceDesk(AtlassianRestAPI):
             "issueTypeId": request_type_id,
             "name": request_name,
             "description": request_description,
-            "helpText": request_help_text,
+            "helpText": request_help_text
         }
             
         url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -704,10 +704,7 @@ class ServiceDesk(AtlassianRestAPI):
             "description": request_description,
             "helpText": request_help_text
         }
-        
-        param_map = {"headers": self.experimental_headers}
-        param_map["data"] = data
            
         url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)
-        return self.post(url, **param_map)
 
+        return self.post(url, headers=self.experimental_headers, data=data)

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -704,13 +704,7 @@ class ServiceDesk(AtlassianRestAPI):
             "description": request_description,
             "helpText": request_help_text,
         }
-
-        param_map = {"headers": self.experimental_headers}
-
-        if isinstance(values_dict, dict):
-            param_map["json"] = data
-        elif isinstance(values_dict, str):
-            param_map["data"] = data
             
         url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)
-        return self.post(url, **param_map)
+        return self.post(url, headers=self.experimental_headers, data=data)
+

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -704,7 +704,10 @@ class ServiceDesk(AtlassianRestAPI):
             "description": request_description,
             "helpText": request_help_text
         }
-            
+        
+        param_map = {"headers": self.experimental_headers}
+        param_map["data"] = data
+           
         url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)
-        return self.post(url, headers=self.experimental_headers, data=data)
+        return self.post(url, **param_map)
 


### PR DESCRIPTION
The _requestType_ API endpoint has a _createRequestType_ method that can be used to create new request types.

Documentation here:
https://docs.atlassian.com/jira-servicedesk/REST/4.13.1/#servicedeskapi/servicedesk/{serviceDeskId}/requesttype-createRequestType

I've added some code to implement this method.