### PR TITLE
Bitbucket: Feature/Update Repo command

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -305,7 +305,7 @@ class Bitbucket(BitbucketBase):
         """
         url = self._url_project(key)
         return self.put(url, data=params)
-    
+
     def _url_project_avatar(self, project_key):
         return "{}/avatar.png".format(self._url_project(project_key))
 

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -682,6 +682,24 @@ class Bitbucket(BitbucketBase):
         url = self._url_repo(project_key, repository_slug)
         return self.get(url)
 
+    def update_repo(self, project_key, repository_slug, **params):
+        """
+        Update a repository in a project. This operates based on slug not name which may
+        be confusing to some users.
+        :param project_key: Key of the project you wish to look in.
+        :param repository_slug: url-compatible repository identifier
+
+        :return: None if the project does not exist, else the value of the put request.
+        """
+        data = self.get_repo(project_key, repository_slug)
+        if "errors" in data:
+            log.debug("Failed to update repo: {0}/{1}: Unable to read repo".format(project_key, repository_slug))
+            return None
+        else:
+            data.update(params)
+            url = self._url_repo(project_key, repository_slug)
+            return self.put(url, data=data)
+
     def delete_repo(self, project_key, repository_slug):
         """
         Delete a specific repository from a project. This operates based on slug not name which may

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -688,7 +688,7 @@ class Bitbucket(BitbucketBase):
         be confusing to some users.
         :param project_key: Key of the project you wish to look in.
         :param repository_slug: url-compatible repository identifier
-        :return: None if the repo does not exist, else the value of the put request.
+        :return: The value of the put request.
         """
         url = self._url_repo(project_key, repository_slug)
         return self.put(url, data=params)

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -301,18 +301,11 @@ class Bitbucket(BitbucketBase):
         """
         Update project
         :param key: The project key
-
-        :return: None if the project does not exist, else the value of the put request.
+        :return: The value of the put request.
         """
-        data = self.project(key)
-        if "errors" in data:
-            log.debug("Failed to update project: {0}: Unable to read project".format(key))
-            return None
-        else:
-            data.update(params)
-            url = self._url_project(key)
-            return self.put(url, data=data)
-
+        url = self._url_project(key)
+        return self.put(url, data=params)
+    
     def _url_project_avatar(self, project_key):
         return "{}/avatar.png".format(self._url_project(project_key))
 

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -690,14 +690,8 @@ class Bitbucket(BitbucketBase):
         :param repository_slug: url-compatible repository identifier
         :return: None if the repo does not exist, else the value of the put request.
         """
-        data = self.get_repo(project_key, repository_slug)
-        if "errors" in data:
-            log.debug("Failed to update repo: {0}/{1}: Unable to read repo".format(project_key, repository_slug))
-            return None
-        else:
-            data.update(params)
-            url = self._url_repo(project_key, repository_slug)
-            return self.put(url, data=data)
+        url = self._url_repo(project_key, repository_slug)
+        return self.put(url, data=params)
 
     def delete_repo(self, project_key, repository_slug):
         """

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -688,8 +688,7 @@ class Bitbucket(BitbucketBase):
         be confusing to some users.
         :param project_key: Key of the project you wish to look in.
         :param repository_slug: url-compatible repository identifier
-
-        :return: None if the project does not exist, else the value of the put request.
+        :return: None if the repo does not exist, else the value of the put request.
         """
         data = self.get_repo(project_key, repository_slug)
         if "errors" in data:

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -47,6 +47,9 @@ Manage repositories
     # Get single repository
     bitbucket.get_repo(project_key, repository_slug)
 
+    # Update single repository
+    bitbucket.update_repo(project_key, repository_slug, description="Repo description")
+
     # Get labels for a single repository
     bitbucket.get_repo_labels(project_key, repository_slug)
 


### PR DESCRIPTION
The Update Repo command is missing from the Bitbucket API allowing for updates to repository eg description. 

The method arguments follow the same pattern used by the `update_project` method.

The change covers both code and docs, and all tox checks pass.