### PR TITLE
Add URL encoding for multiple GET parameters

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -197,7 +197,7 @@ class AtlassianRestAPI(object):
         params_already_in_url = True if "?" in url else False
         if (params or flags) and not params_already_in_url:
             url += "?"
-        else:
+        if (params or flags) and params_already_in_url:
             url += "&"
         if params:
             url += urlencode(params or {})

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -195,10 +195,11 @@ class AtlassianRestAPI(object):
         """
         url = self.url_joiner(None if absolute else self.url, path, trailing)
         params_already_in_url = True if "?" in url else False
-        if (params or flags) and not params_already_in_url:
-            url += "?"
-        if (params or flags) and params_already_in_url:
-            url += "&"
+        if (params or flags):
+            if params_already_in_url:
+                url += "&"
+            else:
+                url += "?"   
         if params:
             url += urlencode(params or {})
         if flags:

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -197,6 +197,8 @@ class AtlassianRestAPI(object):
         params_already_in_url = True if "?" in url else False
         if (params or flags) and not params_already_in_url:
             url += "?"
+        else:
+            url += "&"
         if params:
             url += urlencode(params or {})
         if flags:

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -195,11 +195,11 @@ class AtlassianRestAPI(object):
         """
         url = self.url_joiner(None if absolute else self.url, path, trailing)
         params_already_in_url = True if "?" in url else False
-        if (params or flags):
+        if params or flags:
             if params_already_in_url:
                 url += "&"
             else:
-                url += "?"   
+                url += "?"
         if params:
             url += urlencode(params or {})
         if flags:


### PR DESCRIPTION
Disclaimer: I only looked at Jira until now :)

Currently there seems not to be a method which adds multiple GET parameters to the API request. Indeed, these might happen in the future (I will add another Pull Request  to add the "expand" keyword to Jira.issue_field_value() and Jira.issue() ;) )

This Pull Request adds the option to have multiple GET parameters in the URL.