### PR TITLE
[Tests] Replace flake9 with flake8.

### DIFF
--- a/atlassian/bitbucket/server/base.py
+++ b/atlassian/bitbucket/server/base.py
@@ -82,7 +82,7 @@ class BitbucketServerBase(BitbucketBase):
 
         :return: True if the update was successful
         """
-        if self.__can_update == False:
+        if self.__can_update is False:
             raise NotImplementedError("Update not implemented for this object type.")
         data = self.put(None, data=kwargs)
         if "errors" in data:
@@ -97,7 +97,7 @@ class BitbucketServerBase(BitbucketBase):
 
         :return: True if delete was successful
         """
-        if self.__can_delete == False:
+        if self.__can_delete is False:
             raise NotImplementedError("Delete not implemented for this object type.")
         data = super(BitbucketServerBase, self).delete(None)
         if "errors" in data:

--- a/examples/jira/jira_issue_update_epic_link.py
+++ b/examples/jira/jira_issue_update_epic_link.py
@@ -14,7 +14,7 @@ def main():
     epic_link_custom_field_id = "customfield_1404"  # Epic Link Custom Field
     target_epic_issue_key = "ARA-1314"
     for issue_key in update_issues:
-        issue_data = jira.update_issue_field(issue_key, fields={epic_link_custom_field_id: target_epic_issue_key})
+        jira.update_issue_field(issue_key, fields={epic_link_custom_field_id: target_epic_issue_key})
         print(f"updated for {issue_key}")
     print("done")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,6 @@
 # setup.cfg or other tool-specific files.
 # https://github.com/carlosperate/awesome-pyproject
 
-[tool.flake8]
-max-line-length = 120
-exclude = '.tox,docs'
-
 [tool.black]
 line-length = 120
 include = '(atlassian|examples|tests)\/.*(\.py|GET|POST)'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 mock
 -r requirements.txt
-flake9
+flake8
 pytest
 pylint
 tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [pep8]
 max-line-length = 120
 
+[flake8]
+max-line-length = 120
+exclude = .tox,docs
+
 [mypy]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ max-line-length = 120
 
 [flake8]
 max-line-length = 120
+ignore = E203,E501
 exclude = .tox,docs
 
 [mypy]

--- a/tests/mockup.py
+++ b/tests/mockup.py
@@ -2,7 +2,7 @@
 import json
 import os
 
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 
 from requests import Session, Response
 
@@ -47,8 +47,8 @@ def request_mookup(*args, **kwargs):
                         cur_dict = elem if item is None else elem.get(item, {})
                         if "links" in cur_dict:
                             for link in cur_dict["links"].values():
-                                for l in link if type(link) is list else [link]:
-                                    l["href"] = "{}/{}".format(SERVER, l["href"])
+                                for ld in link if type(link) is list else [link]:
+                                    ld["href"] = "{}/{}".format(SERVER, ld["href"])
                 if "next" in data:
                     data["next"] = "{}/{}".format(SERVER, data["next"])
 

--- a/tests/test_bitbucket_cloud.py
+++ b/tests/test_bitbucket_cloud.py
@@ -1,6 +1,4 @@
 # coding: utf8
-import os
-import requests
 import pytest
 import sys
 
@@ -62,7 +60,7 @@ class TestBasic:
         result = BITBUCKET.get_pipeline_step_log(
             "TestWorkspace1", "testrepository1", "{PipelineUuid}", "{PipelineStep1Uuid}"
         )
-        assert result == None, "Result of step1 [get_pipeline_step_log(...)]"
+        assert result is None, "Result of step1 [get_pipeline_step_log(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_get_pipeline_step_log_2(self):
@@ -129,9 +127,9 @@ class TestBasic:
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_is_default_reviewer(self):
         result = BITBUCKET.is_default_reviewer("TestWorkspace1", "testrepository1", "DefaultReviewerNo")
-        assert result == False, "Result of [is_default_reviewer(...)]"
+        assert result is False, "Result of [is_default_reviewer(...)]"
         result = BITBUCKET.is_default_reviewer("TestWorkspace1", "testrepository1", "DefaultReviewer1")
-        assert result == True, "Result of [is_default_reviewer(...)]"
+        assert result is True, "Result of [is_default_reviewer(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_delete_default_reviewer(self):

--- a/tests/test_bitbucket_server.py
+++ b/tests/test_bitbucket_server.py
@@ -1,6 +1,4 @@
 # coding: utf8
-import os
-import requests
 import pytest
 import sys
 
@@ -38,7 +36,7 @@ class TestBasic:
 
         group = BITBUCKET.groups.get("group_a")
         assert group.name == "group_a", "Get a group"
-        assert group.delete() == True, "Delete a group"
+        assert group.delete() is True, "Delete a group"
 
         result = list(BITBUCKET.users.each())
         assert [x.permission for x in result] == [
@@ -78,7 +76,7 @@ class TestBasic:
 
         user = BITBUCKET.users.get("jcitizen1")
         assert user.name == "jcitizen1", "Get a user"
-        assert user.delete() == True, "Delete a user"
+        assert user.delete() is True, "Delete a user"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_projects(self):
@@ -102,9 +100,9 @@ class TestBasic:
         project.description = "New description."
         assert project.description == "New description.", "Update the project description"
 
-        assert project.public == True, "The project public flag"
+        assert project.public is True, "The project public flag"
         project.public = False
-        assert project.public == False, "Update the project public flag"
+        assert project.public is False, "Update the project public flag"
 
         assert project.key == "PRJ", "The project key"
         project.key = "NEWKEY"
@@ -127,7 +125,7 @@ class TestBasic:
 
         group = project.groups.get("group_a")
         assert group.name == "group_a", "Get a group"
-        assert group.delete() == True, "Delete a group"
+        assert group.delete() is True, "Delete a group"
 
         result = list(project.users.each())
         assert [x.permission for x in result] == ["ADMIN", "WRITE", "READ"], "Each permission of project user"
@@ -159,7 +157,7 @@ class TestBasic:
 
         user = project.users.get("jcitizen1")
         assert user.name == "jcitizen1", "Get a user"
-        assert user.delete() == True, "Delete a user"
+        assert user.delete() is True, "Delete a user"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_repositories(self):
@@ -189,13 +187,13 @@ class TestBasic:
         repo.description = "New description."
         assert repo.description == "New description.", "Update the repo description"
 
-        assert repo.public == True, "The repo public flag"
+        assert repo.public is True, "The repo public flag"
         repo.public = False
-        assert repo.public == False, "Update the repo public flag"
+        assert repo.public is False, "Update the repo public flag"
 
-        assert repo.forkable == True, "The repo forkable flag"
+        assert repo.forkable is True, "The repo forkable flag"
         repo.forkable = False
-        assert repo.forkable == False, "Update the repo forkable flag"
+        assert repo.forkable is False, "Update the repo forkable flag"
 
         assert repo.contributing() == "Test contributing.md", "The contributing.md"
         assert repo.contributing(at="CommitId") == "Test contributing.md at CommitId", "The contributing.md at CommitId"
@@ -239,7 +237,7 @@ class TestBasic:
 
         group = repo.groups.get("group_a")
         assert group.name == "group_a", "Get a group"
-        assert group.delete() == True, "Delete a group"
+        assert group.delete() is True, "Delete a group"
 
         result = list(repo.users.each())
         assert [x.permission for x in result] == ["ADMIN", "WRITE", "READ"], "Each permission of repo user"
@@ -267,4 +265,4 @@ class TestBasic:
 
         user = repo.users.get("jcitizen1")
         assert user.name == "jcitizen1", "Get a user"
-        assert user.delete() == True, "Delete a user"
+        assert user.delete() is True, "Delete a user"

--- a/tests/test_servicedesk.py
+++ b/tests/test_servicedesk.py
@@ -1,5 +1,4 @@
 # coding: utf8
-import os
 import pytest
 import sys
 
@@ -54,31 +53,31 @@ class TestBasic:
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_add_organization(self):
         result = SERVICEDESK.add_organization("{serviceDeskId}", "{organizationId}")
-        assert result == None, "Result of [add_organization(...)]"
+        assert result is None, "Result of [add_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_remove_organization(self):
         result = SERVICEDESK.remove_organization("{serviceDeskId}", "{organizationId}")
-        assert result == None, "Result of [remove_organization(...)]"
+        assert result is None, "Result of [remove_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_delete_organization(self):
         result = SERVICEDESK.delete_organization("{organizationId}")
-        assert result == None, "Result of [delete_organization(...)]"
+        assert result is None, "Result of [delete_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_add_users_to_organization(self):
         result = SERVICEDESK.add_users_to_organization(
             "{organizationId}", account_list=["{accountId1}", "{accountId2}"]
         )
-        assert result == None, "Result of [add_users_to_organization(...)]"
+        assert result is None, "Result of [add_users_to_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_remove_users_from_organization(self):
         result = SERVICEDESK.remove_users_from_organization(
             "{organizationId}", account_list=["{accountId1}", "{accountId2}"]
         )
-        assert result == None, "Result of [remove_users_from_organization(...)]"
+        assert result is None, "Result of [remove_users_from_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_get_customers(self):
@@ -88,9 +87,9 @@ class TestBasic:
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_add_customers(self):
         result = SERVICEDESK.add_customers("{serviceDeskId}", list_of_accountids=["{accountId1}", "{accountId2}"])
-        assert result == None, "Result of [remove_users_from_organization(...)]"
+        assert result is None, "Result of [remove_users_from_organization(...)]"
 
     @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4")
     def test_remove_customers(self):
         result = SERVICEDESK.remove_customers("{serviceDeskId}", list_of_accountids=["{accountId1}", "{accountId2}"])
-        assert result == None, "Result of [remove_users_from_organization(...)]"
+        assert result is None, "Result of [remove_users_from_organization(...)]"

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,10 @@ deps = pytest
 commands = pytest -v
 extras = kerberos
 
-[testenv:flake9]
+[testenv:flake8]
 basepython = python3
 skip_install = true
-deps = flake9 # flake9 is a fork of flake8 which supports pyproject.toml files
+deps = flake8
 commands = flake8
 
 [testenv:pylint]


### PR DESCRIPTION
Flake9 can cause troubles without a virtualenv if working on different projects. Therefore switching back to flake8 and using `setup.cfg`instead of `pyproject.toml`.