### PR TITLE
Bitbucket: Fix error in bitbucket cloud example

### DIFF
--- a/examples/bitbucket/bitbucket_cloud_oo.py
+++ b/examples/bitbucket/bitbucket_cloud_oo.py
@@ -17,7 +17,7 @@ for w in cloud.workspaces.each():
         break
 
 print()
-w = cloud.workspaces.get(w.name)
+w = cloud.workspaces.get(w.slug)
 p = w.projects.get(p.key)
 print("Project key " + p.key)
 for r in p.repositories.each():


### PR DESCRIPTION
In encountered an error in the bitbucket cloud example. This PR fixes it. It replaces the parameter for the workspace request. The example tried to get the workspaces by the workspace name. According to the [documentation](https://developer.atlassian.com/bitbucket/api/2/reference/resource/workspaces/%7Bworkspace%7D) they must be requested by the workspace slug:

> This can either be the workspace ID (slug) or the workspace UUID surrounded by curly-braces

Workspace name and slug are often the same, but in case they are different, the example fails:
`requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.bitbucket.org/2.0/workspaces/...`