### PR TITLE
Add coverage report.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile.qa
+++ b/Dockerfile.qa
@@ -2,20 +2,30 @@ FROM ubuntu:20.04
 
 ARG PYTHON_VERSION
 
-RUN \
-  apt update && \
-  apt-get install -y make gcc-8 libkrb5-dev python$PYTHON_VERSION python3-pip && \
-  apt-get clean
+# Install add-apt-repository
+RUN apt-get update
+RUN apt-get install -y software-properties-common
 
+# Install python development
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
+RUN apt-get install -y python$PYTHON_VERSION-dev python3-pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PYTHON_VERSION 1
+
+# Install kerberos development
+RUN apt-get install -y libkrb5-dev
+
+# Clean
+RUN apt-get clean
+
+# Install modules
 WORKDIR /atlassian-python-api
 COPY requirements.txt .
 COPY requirements-dev.txt .
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN python3 -m pip install --no-cache-dir -r requirements-dev.txt
 
-ENV PYTHON_VERSION=PYTHON_VERSION
-
-RUN \
-  python3 -m pip install --no-cache-dir --upgrade pip && \
-  python3 -m pip install --no-cache-dir -r requirements-dev.txt
+ENV PYTHON_VERSION=$PYTHON_VERSION
 
 CMD python3 -m pip install -e . && \
   make qa PYTHON_VERSION=$PYTHON_VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@
 
 PYTHON_VERSION ?= 3.7
 
-
 QA_CONTAINER ?= atlassian-python-api-qa-$(PYTHON_VERSION)
 TEST_OPTS ?=
+
+LINTING_TARGETS := atlassian/ examples/ tests/
 
 .PHONY: help setup-dev qa lint test doc docker-qa docker-qa-build
 

--- a/atlassian-python-api.code-workspace
+++ b/atlassian-python-api.code-workspace
@@ -7,10 +7,8 @@
 	"settings": {
 		"files.exclude": {
 			".mypy_cache": true,
-			".tox": true,
 			"**/__pycache__": true,
 			"**/*.pyc": true,
-			"atlassian_python_api.egg-info": true
 		},
 		"files.associations": {
 			"DELETE": "python",

--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -1,7 +1,13 @@
 # coding=utf-8
 
+import re
+import sys
+
 from datetime import datetime
 from ..rest_client import AtlassianRestAPI
+
+
+RE_TIMEZONE = re.compile(r"(\d{2}):(\d{2})$")
 
 
 class BitbucketBase(AtlassianRestAPI):
@@ -77,6 +83,9 @@ class BitbucketBase(AtlassianRestAPI):
             return value_str
 
         if isinstance(value_str, str):
+            # The format contains a : in the timezone which is supported from 3.7 on.
+            if sys.version_info <= (3, 7):
+                value_str = RE_TIMEZONE.sub(r"\1\2", value_str)
             value = datetime.strptime(value_str, self.CONF_TIMEFORMAT)
         else:
             value = value_str

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
-mock
 -r requirements.txt
-flake8
+mock
 pytest
-pylint
+pytest-cov
+flake8
+black
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,21 @@
 linting_targets = atlassian/ examples/ tests/
 
 [tox]
-envlist = py27,py3,flake8,black,mypy,bandit,doc8
+envlist = py3,flake8,black,mypy,bandit,doc8
 skip_missing_interpreters = True
 
 [testenv]
-deps = pytest
-commands = pytest -v
+deps =
+    pytest
+    pytest-cov
+    coverage
+commands =
+    coverage erase
+    pytest -v --cov=atlassian --cov-branch
+    coverage report --omit='.tox/*'
+    coverage html --omit='.tox/*'
 extras = kerberos
+parallel_show_output = true
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
There was a problem with the different python versions. Effectivly only version 3.8.5, which is the default in the docker ubuntu, was used. Now 3.6, 3.7, 3.8 and 3.9 are used.

At the moment the result is only visible inside the log of tox. To make the result vissible in the PR a project in Codecov is needed and the token must be added to this project to be able to upload the data from the GitHub action. We should also define from which python version the result is uploaded.
You can see in https://github.com/gcovr/gcovr/pull/445 how it can look like.

Should we install all python versions inside the docker container and run tox with all python versions?
Closes #657