### PR TITLE
Docs: Fix typo in documentation theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alibaster"
+html_theme = "alabaster"
 html_theme_options = {
     "rightsidebar": "false",
 }


### PR DESCRIPTION
I tried to generate the documentation but it failed due to missing theme 'alibaster'. I assume 'alabaster' was meant. 

The documentation theme has been adapted several times. Last time it was reverted to 'alibaster' instead of 'alabaster' (https://github.com/atlassian-api/atlassian-python-api/commit/0b36c5f0079f1179332c63fe82f4c44c52f01fd3#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3).

I changed it to the correct theme.