### PR TITLE
Bitbucket: Corrected documentation for cloud authentication

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -212,7 +212,7 @@ And to Bitbucket Cloud:
         username=bitbucket_email,
         password=bitbucket_password,
         cloud=True)
-    
+
     bitbucket_app_pw = Cloud(
         url='https://api.bitbucket.org/',
         username=bitbucket_username,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,11 +170,12 @@ Or reuse cookie file:
         url='http://localhost:8080',
         cookies=cookie_dict)
 
-To authenticate to the Atlassian Cloud APIs:
+To authenticate to the Atlassian Cloud APIs Jira, Confluence, ServiceDesk:
 
 .. code-block:: python
 
     # Obtain an API token from: https://id.atlassian.com/manage-profile/security/api-tokens
+    # You cannot log-in with your regular password to these services.
 
     jira = Jira(
         url='https://your-domain.atlassian.net',
@@ -188,16 +189,34 @@ To authenticate to the Atlassian Cloud APIs:
         password=jira_api_token,
         cloud=True)
 
-    bitbucket = Bitbucket(
+    service_desk = ServiceDesk(
         url='https://your-domain.atlassian.net',
         username=jira_username,
         password=jira_api_token,
         cloud=True)
 
-    service_desk = ServiceDesk(
-        url='https://your-domain.atlassian.net',
-        username=jira_username,
-        password=jira_api_token,
+And to Bitbucket Cloud:
+
+.. code-block:: python
+
+    # Log-in with E-Mail / Username and regular password
+    # or with Username and App password.
+    # Get App password from https://bitbucket.org/account/settings/app-passwords/.
+    # Log-in with E-Mail and App password not possible.
+    # Username can be found here: https://bitbucket.org/account/settings/
+
+    from atlassian.bitbucket.cloud import Cloud
+
+    bitbucket = Cloud(
+        url='https://api.bitbucket.org/',
+        username=bitbucket_email,
+        password=bitbucket_password,
+        cloud=True)
+    
+    bitbucket_app_pw = Cloud(
+        url='https://api.bitbucket.org/',
+        username=bitbucket_username,
+        password=bitbucket_app_password,
         cloud=True)
 
 .. toctree::


### PR DESCRIPTION
I changed the chapter for the cloud authentication in the documentation. They were outdated and had some errors. Also added some hints.
* Created additional section for Bitbucket cloud authentication, because it differs from the other services.
* Updated to new Cloud class, because others are marked deprecated.
* Gave more information how you can provide your credentials.
* Add information you cannot login with regular password for Jira etc.
* Corrected cloud link