### PR TITLE
Docs: Add configuration file for read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Documentation builds on read the docs are currently failing. The documentation build is trying to install all required pip packages for development. It fails for one C-package that needs compilation.

The documentation build does not need all these packages. The configuration can be changed in the admin panel of read the docs or with a configuration file. A configuration file is the recommended way.

This commit introduces a basic configuration file for the read the docs documentation build.