### PR TITLE
Docs: Get documentation version from VERSION file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,11 @@ author = "SLRover"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "1.15.3"
+release = ""
+
+with open(os.path.join("../atlassian", "VERSION")) as file:
+    version = file.read().strip()
+    release = version
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
The version of the documentation is configured in the `conf.py` file. The version has not been increased there for a longer time. On Read the Docs you can find the version information for the library in the title for example. So it looks like the documentation refers to an older version of the library.
<img width="235" alt="version_documentation" src="https://user-images.githubusercontent.com/62656589/103440364-1e50d380-4c45-11eb-834b-39a953fa1e62.png">

The current version of the library is in the `atlassian/VERSION` file. In oder to keep the process simple, I changed the `conf.py` so that the documentation now also takes the version information from the `VERSION` file. By that the version information of the library and the documentation is always in sync.

I set both `release` and `version` to the same value. I think there is no distinction needed for this project.

I tested it locally and it worked well.

[Background informations](https://www.sphinx-doc.org/en/master/usage/configuration.html)