### PR TITLE
Docs: Ignore build folder in doc8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,4 +53,4 @@ skip_install = true
 deps =
     sphinx
     doc8
-commands = doc8 docs/
+commands = doc8 --ignore-path docs/_build/ docs/


### PR DESCRIPTION
When documentation has been built and quality check is run afterwards, it always fails because of errors in the docs/_build/ folder. This is because doc8 is also scanning the generated documentation files for errors.
<img width="304" alt="doc8_error" src="https://user-images.githubusercontent.com/62656589/103537048-f0150300-4e93-11eb-9862-372950cb7656.png">

This commit is adding an ignore-parameter to the call to doc8. With this the build folder is ignored.