### PR TITLE
Docs: Remove Key-Cert authentication info

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,45 +49,10 @@ Add a connection:
         username='admin',
         password='admin')
 
-Key/Cert Based authentication
------------------------------
+Other authentication methods
+----------------------------
 
-Add a connection using key/cert based authentication:
-
-.. code-block:: python
-
-    from atlassian import Jira
-    from atlassian import Confluence
-    from atlassian import Bitbucket
-    from atlassian import ServiceDesk
-    from atlassian import Xray
-
-    jira = Jira(
-        url='http://localhost:8080',
-        key='/path/to/key',
-        cert='/path/to/cert')
-
-    confluence = Confluence(
-        url='http://localhost:8090',
-        key='/path/to/key',
-        cert='/path/to/cert')
-
-    bitbucket = Bitbucket(
-        url='http://localhost:7990',
-        key='/path/to/key',
-        cert='/path/to/cert')
-
-    service_desk = ServiceDesk(
-        url='http://localhost:8080',
-        key='/path/to/key',
-        cert='/path/to/cert')
-
-    xray = Xray(
-        url='http://localhost:8080',
-        key='/path/to/key',
-        cert='/path/to/cert')
-
-Alternatively OAuth can be used:
+Further authentication methods are available. For example OAuth can be used:
 
 .. code-block:: python
 


### PR DESCRIPTION
Documentation gave information about authentication with key and certificate. I could not find this authentication method in the code and as well not in the Atlassian documentation.

Therefore, I removed the chapter is removed and the other authentication methods are grouped with a new title. Maybe you have more information what could be meant there?