### PR TITLE
Bitbucket Cloud: Set default url

### DIFF
--- a/atlassian/bitbucket/cloud/__init__.py
+++ b/atlassian/bitbucket/cloud/__init__.py
@@ -6,7 +6,7 @@ from .repositories import Repositories
 
 
 class Cloud(BitbucketCloudBase):
-    def __init__(self, url, *args, **kwargs):
+    def __init__(self, url="https://api.bitbucket.org/", *args, **kwargs):
         kwargs["cloud"] = True
         kwargs["api_root"] = None
         kwargs["api_version"] = "2.0"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,7 +121,7 @@ OAuth 2.0 is also supported:
 
 .. code-block:: python
 
-    from atlassian.bitbucket.cloud import Cloud
+    from atlassian.bitbucket import Cloud
 
     # token is a dictionary and must at least contain "access_token"
     # and "token_type".
@@ -224,7 +224,7 @@ And to Bitbucket Cloud:
     # Log-in with E-Mail and App password not possible.
     # Username can be found here: https://bitbucket.org/account/settings/
 
-    from atlassian.bitbucket.cloud import Cloud
+    from atlassian.bitbucket import Cloud
 
     bitbucket = Cloud(
         username=bitbucket_email,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,7 +130,6 @@ OAuth 2.0 is also supported:
         "token": token}
 
     bitbucket_cloud = Cloud(
-        url='https://api.bitbucket.org/',
         oauth2=oauth2_dict)
 
     # For a detailed example see bitbucket_oauth2.py in
@@ -228,13 +227,11 @@ And to Bitbucket Cloud:
     from atlassian.bitbucket.cloud import Cloud
 
     bitbucket = Cloud(
-        url='https://api.bitbucket.org/',
         username=bitbucket_email,
         password=bitbucket_password,
         cloud=True)
 
     bitbucket_app_pw = Cloud(
-        url='https://api.bitbucket.org/',
         username=bitbucket_username,
         password=bitbucket_app_password,
         cloud=True)

--- a/examples/bitbucket/bitbucket_cloud_oo.py
+++ b/examples/bitbucket/bitbucket_cloud_oo.py
@@ -4,7 +4,7 @@ from textwrap import indent
 
 from atlassian.bitbucket import Cloud
 
-cloud = Cloud(username="admin", password="admin")
+cloud = Cloud(url="https://api.bitbucket.org/", username="admin", password="admin")
 
 index = 0
 for w in cloud.workspaces.each():

--- a/examples/bitbucket/bitbucket_cloud_oo.py
+++ b/examples/bitbucket/bitbucket_cloud_oo.py
@@ -2,9 +2,9 @@
 
 from textwrap import indent
 
-from atlassian.bitbucket.cloud import Cloud
+from atlassian.bitbucket import Cloud
 
-cloud = Cloud(url="http://localhost:7990", username="admin", password="admin")
+cloud = Cloud(username="admin", password="admin")
 
 index = 0
 for w in cloud.workspaces.each():

--- a/examples/bitbucket/bitbucket_oauth2.py
+++ b/examples/bitbucket/bitbucket_oauth2.py
@@ -4,7 +4,7 @@
 # token and the available workspaces are returned.
 
 from requests_oauthlib import OAuth2Session
-from atlassian.bitbucket.cloud import Cloud
+from atlassian.bitbucket import Cloud
 from flask import Flask, request, redirect, session
 
 app = Flask(__name__)
@@ -52,6 +52,6 @@ def callback():
 def get_workspaces(token):
     oauth2 = {"client_id": client_id, "token": token}
 
-    bitbucket = Cloud(url="https://api.bitbucket.org/", oauth2=oauth2, cloud=True)
+    bitbucket = Cloud(oauth2=oauth2, cloud=True)
 
     return [ws.name for ws in bitbucket.workspaces.each()]

--- a/examples/bitbucket/bitbucket_oauth2.py
+++ b/examples/bitbucket/bitbucket_oauth2.py
@@ -52,6 +52,6 @@ def callback():
 def get_workspaces(token):
     oauth2 = {"client_id": client_id, "token": token}
 
-    bitbucket = Cloud(oauth2=oauth2, cloud=True)
+    bitbucket = Cloud(url="https://api.bitbucket.org/", oauth2=oauth2, cloud=True)
 
     return [ws.name for ws in bitbucket.workspaces.each()]


### PR DESCRIPTION
Unlike the server variants, the url for the Bitbucket cloud is always the same. There is no need to write the url every time, when the Cloud class should be used. Also for new users of this library it can be confusing, where to find the Bitbucket cloud url.

Therefore, this commit sets for the url parameter of the Bitbucket Cloud class to a default value. It still can be modified by giving another url as parameter (i.e. for tests). Also adapted documentation and examples.