### PR TITLE
[Jira Service management] Update service_desk.py

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -471,7 +471,7 @@ class ServiceDesk(AtlassianRestAPI):
         experimental_headers = self.experimental_headers.copy()
         del experimental_headers["Content-Type"]
         experimental_headers["X-Atlassian-Token"] = "no-check"
-            
+
         with open(filename, "rb") as file:
             result = self.post(path=url, headers=experimental_headers, files={"file": file}).get("temporaryAttachments")
             temp_attachment_id = result[0].get("temporaryAttachmentId")

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -466,8 +466,14 @@ class ServiceDesk(AtlassianRestAPI):
         """
         url = "rest/servicedeskapi/servicedesk/{}/attachTemporaryFile".format(service_desk_id)
 
+        # no application/json content type and an additional X-Atlassian-Token header
+        # https://docs.atlassian.com/jira-servicedesk/REST/4.14.1/#servicedeskapi/servicedesk/{serviceDeskId}/attachTemporaryFile-attachTemporaryFile
+        experimental_headers = self.experimental_headers.copy()
+        del experimental_headers['Content-Type']
+        experimental_headers['X-Atlassian-Token'] = 'no-check'
+            
         with open(filename, "rb") as file:
-            result = self.post(path=url, headers=self.experimental_headers, files={"file": file}).get(
+            result = self.post(path=url, headers=experimental_headers, files={"file": file}).get(
                 "temporaryAttachments"
             )
             temp_attachment_id = result[0].get("temporaryAttachmentId")

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -469,13 +469,11 @@ class ServiceDesk(AtlassianRestAPI):
         # no application/json content type and an additional X-Atlassian-Token header
         # https://docs.atlassian.com/jira-servicedesk/REST/4.14.1/#servicedeskapi/servicedesk/{serviceDeskId}/attachTemporaryFile-attachTemporaryFile
         experimental_headers = self.experimental_headers.copy()
-        del experimental_headers['Content-Type']
-        experimental_headers['X-Atlassian-Token'] = 'no-check'
+        del experimental_headers["Content-Type"]
+        experimental_headers["X-Atlassian-Token"] = "no-check"
             
         with open(filename, "rb") as file:
-            result = self.post(path=url, headers=experimental_headers, files={"file": file}).get(
-                "temporaryAttachments"
-            )
+            result = self.post(path=url, headers=experimental_headers, files={"file": file}).get("temporaryAttachments")
             temp_attachment_id = result[0].get("temporaryAttachmentId")
 
             return temp_attachment_id


### PR DESCRIPTION
with the default 'application/json' content-type the upload is not working
in the documentation there is a hint which headers should be set
if the X-Atlassian-Token is missing you receive a 404