### PR TITLE
[REST Client] Kerberos authentication improvements

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -87,21 +87,10 @@ class AtlassianRestAPI(object):
     def _create_basic_session(self, username, password):
         self._session.auth = (username, password)
 
-    def _create_kerberos_session(self, kerberos_service):
-        try:
-            import kerberos as kerb
-        except ImportError as e:
-            log.debug(e)
-            try:
-                import kerberos_sspi as kerb
-            except ImportError:
-                raise ImportError("No kerberos implementation available")
-        __, krb_context = kerb.authGSSClientInit(kerberos_service)
-        kerb.authGSSClientStep(krb_context, "")
-        auth_header = "Negotiate " + kerb.authGSSClientResponse(krb_context)
-        self._update_header("Authorization", auth_header)
-        response = self._session.get(self.url, verify=self.verify_ssl)
-        response.raise_for_status()
+    def _create_kerberos_session(self, kerberos_dict):
+        from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+        self._session.auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
 
     def _create_oauth_session(self, oauth_dict):
         oauth = OAuth1(

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -87,7 +87,7 @@ class AtlassianRestAPI(object):
     def _create_basic_session(self, username, password):
         self._session.auth = (username, password)
 
-    def _create_kerberos_session(self, kerberos_dict):
+    def _create_kerberos_session(self, _):
         from requests_kerberos import HTTPKerberosAuth, OPTIONAL
 
         self._session.auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,27 +105,25 @@ Or Kerberos *(installation with kerberos extra necessary)*:
 
 .. code-block:: python
 
-    kerberos_service = 'HTTP/jira.localhost@YOUR.DOMAIN.COM'
-
     jira = Jira(
         url='http://localhost:8080',
-        kerberos=kerberos_service)
+        kerberos={})
 
     confluence = Confluence(
         url='http://localhost:8090',
-        kerberos=kerberos_service)
+        kerberos={})
 
     bitbucket = Bitbucket(
         url='http://localhost:7990',
-        kerberos=kerberos_service)
+        kerberos={})
 
     service_desk = ServiceDesk(
         url='http://localhost:8080',
-        kerberos=kerberos_service)
+        kerberos={})
 
     xray = Xray(
         url='http://localhost:8080',
-        kerberos=kerberos_service)
+        kerberos={})
 
 Or reuse cookie file:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ requests
 six
 oauthlib
 requests_oauthlib
-kerberos; platform_system!='Windows'
-kerberos-sspi; platform_system=='Windows'
+requests-kerberos

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=["deprecated", "requests", "six", "oauthlib", "requests_oauthlib"],
-    extras_require={
-        "kerberos": [
-            'kerberos-sspi ; platform_system=="Windows"',
-            'kerberos ; platform_system!="Windows"',
-        ]
-    },
+    extras_require={"kerberos": ['requests-kerberos']},
     platforms="Platform Independent",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
The package currently used on windows is broken on Python 3.9 (PR pending, but the project isn't very active). This PR replaces both kerberos packages with [`requests-kerberos`](https://github.com/requests/requests-kerberos), allowing some improvements:

- Single package, no difference for windows
- API is closer to *oauth*, using a map (the parameter isn't used yet)
- Less code
- Python 3.9 compatibility

##### Why not _requests-gssapi_?

It requires external installation of a additional executables on Windows.


## TODO / Discussion

- [x] Docs: Update example
- [x] Is `OPTIONAL` a good default for mutual authentication (if not, it should be configurable though)?
- [x] What parameters should be configurable through the parameter?

