### PR TITLE
[Test] Upload coverage data to codecov.io.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,9 @@ jobs:
       run: |
         .github/bump_version ./ minor > atlassian/VERSION
         make docker-qa PYTHON_VERSION=${{matrix.python-version}}
-    
+    - name: Creating coverage report
+      if: ${{ ( matrix.python-version == '3.8' ) }}
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ pytest-cov
 flake8
 black
 tox
+coverage
+codecov

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     coverage
 commands =
     coverage erase
-    pytest -v --cov=atlassian --cov-branch
+    pytest -v --cov=atlassian --cov-branch --cov-report=xml
     coverage html
 extras = kerberos
 parallel_show_output = true


### PR DESCRIPTION
@gonchik For public repositories no token is needed. Th codecov.io can be marked as needed request. It fails if the converage decrease.