### PR TITLE
Correct value for "X-Atlassian-Token" field in HTTP header - confluence.py (attach_content)

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -846,7 +846,7 @@ class Confluence(AtlassianRestAPI):
                 "comment": comment,
                 "minorEdit": "true",
             }
-            headers = {"X-Atlassian-Token": "nocheck", "Accept": "application/json"}
+            headers = {"X-Atlassian-Token": "no-check", "Accept": "application/json"}
             path = "rest/api/content/{page_id}/child/attachment".format(page_id=page_id)
             # Check if there is already a file with the same name
             attachments = self.get(path=path, headers=headers, params={"filename": name})


### PR DESCRIPTION
X-Atlassian-Token should be set to “no-check” instead of “nocheck”.
See https://developer.atlassian.com/server/confluence/form-token-handling/

Otherwise the following warning appears in the server log:
[common.security.jersey.XsrfResourceFilter] hasDeprecatedHeaderValue Use of the 'nocheck' value for X-Atlassian-Token has been deprecated since rest 3.0.0. Please use a value of 'no-check' instead.

Also see issue #696