### PR TITLE
[Bitbucket] Fix Python 2.7 incompatibility

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pullRequests.py
+++ b/atlassian/bitbucket/cloud/repositories/pullRequests.py
@@ -363,7 +363,7 @@ class Build(BitbucketCloudBase):
     STATE_STOPPED = "STOPPED"
     STATE_SUCCESSFUL = "SUCCESSFUL"
 
-    def __init__(self, data, *args, **kwargs) -> None:
+    def __init__(self, data, *args, **kwargs):
         super(Build, self).__init__(None, None, *args, data=data, expected_type="build", **kwargs)
 
     @property


### PR DESCRIPTION
Remove function annotation since this syntax is not supported in Python 2.7
Fix for #704