### PR TITLE
fix bug with dictionary getting

### DIFF
--- a/examples/confluence/confluence_check_unknown_attachment_error.py
+++ b/examples/confluence/confluence_check_unknown_attachment_error.py
@@ -42,6 +42,6 @@ def check_unknown_attachment_in_space(space_key):
 
 if __name__ == "__main__":
     space_list = confluence.get_all_spaces()
-    for space in space_list:
+    for space in space_list["results"]:
         print("Start review {} space".format(space["key"]))
         check_unknown_attachment_in_space(space["key"])


### PR DESCRIPTION
Was getting an error saying:
File "/Users/xxx/atlassian/atlassian-python-api/examples/confluence/confluence_check_unknown_attachment_error.py", line 50, in <module>
    print("Start review {} space".format(space["key"]))
TypeError: string indices must be integers

the space in the space_list was returning 
{'results': [{'id': 1146881, 'key': 'AR',...

.. instead of just the list of spaces, so this circumvents the error.