### PR TITLE
[JIRA] User search required parameters additions

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1472,21 +1472,21 @@ class Jira(AtlassianRestAPI):
                 params["accountId"] = account_id
             elif account_id and query:
                 return "You cannot specify both the query and account_id parameters"
-            elif not account_id and not query and not property_key:
+            elif not any([account_id, query, property_key]):
                 return "You must specify at least one parameter: query or account_id or property_key"
             elif username:
                 return "Jira Cloud no longer supports a username parameter, use account_id, query or property_key"
+
+            if query:
+                params["query"] = query
+            if property_key:
+                params["property"] = property_key
         elif not username:
             return "Username parameter is required for user search on Jira Server"
-
-        if username:
+        elif any([account_id, query, property_key]):
+            return "Jira Server does not support account_id, query or property_key parameters"
+        else:
             params["username"] = username
-
-        if self.cloud and query:
-            params["query"] = query
-
-        if self.cloud and property_key:
-            params["property"] = property_key
 
         return self.get(url, params=params)
 

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1432,6 +1432,7 @@ class Jira(AtlassianRestAPI):
 
     def user_find_by_user_string(
         self,
+        username=None,
         query=None,
         account_id=None,
         property_key=None,
@@ -1444,6 +1445,8 @@ class Jira(AtlassianRestAPI):
         Fuzzy search using display name, emailAddress or property, or an exact search for accountId
         You can use only one parameter: query, account_id or property
 
+        :param username: OPTIONAL: Required for Jira Server, cannot be used on Jira Cloud.
+                Use '.' to find all users.
         :param query: OPTIONAL: String matched against "displayName" and "emailAddress" user attributes
         :param account_id: OPTIONAL: String matched exactly against a user "accountId".
                 Required unless "query" or "property" parameters are specified.
@@ -1464,12 +1467,20 @@ class Jira(AtlassianRestAPI):
             "maxResults": limit,
         }
 
-        if account_id and not query:
-            params["accountId"] = account_id
-        elif account_id and query:
-            return "You cannot specify both the query and account_id parameters"
-        elif not account_id and not query and not property_key:
-            return "You must specify at least one parameter: query or account_id or property_key"
+        if self.cloud:
+            if account_id and not query:
+                params["accountId"] = account_id
+            elif account_id and query:
+                return "You cannot specify both the query and account_id parameters"
+            elif not account_id and not query and not property_key:
+                return "You must specify at least one parameter: query or account_id or property_key"
+            elif username:
+                return "Jira Cloud no longer supports a username parameter, use account_id, query or property_key"
+        elif not username:
+            return "Username parameter is required for user search on Jira Server"
+
+        if username:
+            params["username"] = username
 
         if query:
             params["query"] = query

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1441,10 +1441,9 @@ class Jira(AtlassianRestAPI):
         include_active_users=True,
     ):
         """
-        Fuzzy search using username and display name
-        You can use only one parameter: username, query, account_id or property
+        Fuzzy search using display name, emailAddress or property, or an exact search for accountId
+        You can use only one parameter: query, account_id or property
 
-        :param username: OPTIONAL: Use '.' to find all users
         :param query: OPTIONAL: String matched against "displayName" and "emailAddress" user attributes
         :param account_id: OPTIONAL: String matched exactly against a user "accountId".
                 Required unless "query" or "property" parameters are specified.

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1482,10 +1482,10 @@ class Jira(AtlassianRestAPI):
         if username:
             params["username"] = username
 
-        if query:
+        if self.cloud and query:
             params["query"] = query
 
-        if property_key:
+        if self.cloud and property_key:
             params["property"] = property_key
 
         return self.get(url, params=params)

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1432,7 +1432,6 @@ class Jira(AtlassianRestAPI):
 
     def user_find_by_user_string(
         self,
-        username=None,
         query=None,
         account_id=None,
         property_key=None,
@@ -1469,12 +1468,9 @@ class Jira(AtlassianRestAPI):
         if account_id and not query:
             params["accountId"] = account_id
         elif account_id and query:
-            return "You cannot specify both a query and account_id"
+            return "You cannot specify both the query and account_id parameters"
         elif not account_id and not query and not property_key:
             return "You must specify at least one parameter: query or account_id or property_key"
-
-        if username:
-            params["username"] = username
 
         if query:
             params["query"] = query

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1442,8 +1442,10 @@ class Jira(AtlassianRestAPI):
         include_active_users=True,
     ):
         """
-        Fuzzy search using display name, emailAddress or property, or an exact search for accountId
-        You can use only one parameter: query, account_id or property
+        Fuzzy search using display name, emailAddress or property, or an exact search for accountId or username
+
+        On Jira Cloud, you can use only one of query or account_id params. You may not specify username.
+        On Jira Server, you must specify a username. You may not use query, account_id or property_key.
 
         :param username: OPTIONAL: Required for Jira Server, cannot be used on Jira Cloud.
                 Use '.' to find all users.
@@ -1468,14 +1470,14 @@ class Jira(AtlassianRestAPI):
         }
 
         if self.cloud:
-            if account_id and not query:
-                params["accountId"] = account_id
+            if username:
+                return "Jira Cloud no longer supports a username parameter, use account_id, query or property_key"
             elif account_id and query:
                 return "You cannot specify both the query and account_id parameters"
             elif not any([account_id, query, property_key]):
                 return "You must specify at least one parameter: query or account_id or property_key"
-            elif username:
-                return "Jira Cloud no longer supports a username parameter, use account_id, query or property_key"
+            elif account_id:
+                params["accountId"] = account_id
 
             if query:
                 params["query"] = query

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -37,7 +37,7 @@ Manage users
 .. code-block:: python
 
     # Get user
-    jira.user(username)
+    jira.user(account_id)
 
     # Remove user
     jira.user_remove(username)
@@ -48,8 +48,8 @@ Manage users
     # Get web sudo cookies using normal http request
     jira.user_get_websudo()
 
-    # Fuzzy search using username and display name
-    jira.user_find_by_user_string(username, start=0, limit=50, include_inactive_users=False)
+    # Fuzzy search using emailAddress or displayName
+    jira.user_find_by_user_string(query, start=0, limit=50, include_inactive_users=False)
 
 Manage groups
 -------------


### PR DESCRIPTION
The GDPR changes to the REST API have removed the username parameter from the user search endpoint and now requires either a query, accountId or property parameter be specified otherwise the request will fail. According to the API documentation, a query and accountId cannot both be provided otherwise the request will fail.

This PR brings the Python Jira.user_find_by_user_string() method into alignment with the REST API's post-GDPR changes. It also updates the associated documentation per the contribution guidelines. I tested the functionality against Jira Cloud that my company uses and it worked as expected.

Fixes #726. See that issue for more details. This method is broken until this PR is merged.