### PR TITLE
[JIRA] Support private endpoint for creating new projects based on a template project

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1534,11 +1534,7 @@ class Jira(AtlassianRestAPI):
         :param str lead: The username of the project lead
         :return:
         """
-        json = {
-            "key": key,
-            "name": name,
-            "lead": lead
-        }
+        json = {"key": key, "name": name, "lead": lead}
 
         return self.post("rest/project-templates/1.0/createshared/{}".format(project_id), json=json)
 

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1525,6 +1525,23 @@ class Jira(AtlassianRestAPI):
         """
         return self.post("rest/api/2/project", json=json)
 
+    def create_project_from_shared_template(self, project_id, key, name, lead):
+        """
+        Creates a new project based on an existing project.
+        :param str project_id: The numeric ID of the project to clone
+        :param str key: The KEY to use for the new project, e.g. KEY-10000
+        :param str name: The name of the new project
+        :param str lead: The username of the project lead
+        :return:
+        """
+        json = {
+            "key": key,
+            "name": name,
+            "lead": lead
+        }
+
+        return self.post("rest/project-templates/1.0/createshared/{}".format(project_id), json=json)
+
     def delete_project(self, key):
         """
         DELETE /rest/api/2/project/<project_key>


### PR DESCRIPTION
There exists a private `project-templates` API endpoint for creating a new project based on an existing project: `rest/project-templates/1.0/createshared`. This PR adds support for this using a new `Jira.create_project_from_shared_template()` method.

This private interface has been described in the following discussions from which I derived this: [[1](https://community.atlassian.com/t5/Jira-questions/rest-api-use-existing-projects-configuration-when-creating-a-new/qaq-p/269708)], [[2](https://community.atlassian.com/t5/Answers-Developer-Questions/Create-new-Project-via-REST-based-on-existing-Project/qaq-p/527104)], [[3](https://community.atlassian.com/t5/Jira-questions/How-to-create-project-with-shared-Configuration-via-REST-API/qaq-p/650062
)], [[4](https://jira.atlassian.com/browse/JRASERVER-27256?focusedCommentId=2350805&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2350805)]

This PR would close #553. From that issue, we already support the public endpoint `/rest/api/2/project` for creating new projects from a raw JSON payload. Using that public interface, one can specify an existing workflow scheme to utilize for the new project. However, there's no way to specify extra settings like permission schemes, issue type schemes, etc. which is what this private endpoint allows and what some valid use cases require.