### PR TITLE
[JIRA] Fix get_plugins_info method request in need of trailing slash

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2383,7 +2383,7 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         :return a json of installed plugins
         """
         url = "rest/plugins/1.0/"
-        return self.get(url, headers=self.no_check_headers)
+        return self.get(url, headers=self.no_check_headers, trailing=True)
 
     def upload_plugin(self, plugin_path):
         """


### PR DESCRIPTION
The `Jira.get_plugins_info()` method is currently broken. Calling this method results in a 404 client error:

```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://platformsh.atlassian.net/rest/plugins/1.0
```

The issue is the URL should have a trailing slash but we don't set `trailing=True` when calling the `Jira.get()` method in the return. This remedies that situation and fixes #703.