### PR TITLE
[Bamboo] Fix broken stop build method

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -565,7 +565,7 @@ class Bamboo(AtlassianRestAPI):
         :return: GET request
         """
         resource = "/build/admin/stopPlan.action?planKey={}".format(plan_key)
-        return self.get(path=resource)
+        return self.post(path=resource, headers=self.no_check_headers)
 
     """ Comments & Labels """
 


### PR DESCRIPTION
This method should not use GET, but POST. Otherwise, this functionality will not work as intended. Resulting in 500 returned from Bamboo.

Tested on Bamboo 7.2.2
```
>>> Bamboo(url="https://example.com", username="user", password="pass", advanced_mode=True)
<atlassian.bamboo.Bamboo object at 0x1079c8160>
>>> bamboo = _
>>> bamboo.stop_build("FOO-BAR")
<Response [200]>
```

This should fix the discussion about it here https://github.com/atlassian-api/atlassian-python-api/commit/1a101ee011068a8b40efaad21013faca18c346eb.


Signed-off-by: Martin Styk <mstyk@netsuite.com>