### PR TITLE
Jira, Confluence: Exceptions contain message provided by server

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -2638,3 +2638,18 @@ class Confluence(AtlassianRestAPI):
         url = "rest/jira-metadata/1.0/metadata/cache"
         params = {"globalId": global_id}
         return self.delete(url, params=params)
+
+    def raise_for_status(self, response):
+        """
+        Checks the response for an error status and raises an exception with the error message provided by the server
+        :param response:
+        :return:
+        """
+        if 400 <= response.status_code < 600:
+            try:
+                j = response.json()
+                error_msg = j["message"]
+            except Exception:
+                response.raise_for_status()
+
+            raise HTTPError(error_msg, response=response)

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -3687,3 +3687,18 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
             # check as support tools
             response = self.get("rest/supportHealthCheck/1.0/check/")
         return response
+
+    def raise_for_status(self, response):
+        """
+        Checks the response for an error status and raises an exception with the error message provided by the server
+        :param response:
+        :return:
+        """
+        if 400 <= response.status_code < 600:
+            try:
+                j = response.json()
+                error_msg = "\n".join(j["errorMessages"])
+            except Exception:
+                response.raise_for_status()
+
+            raise HTTPError(error_msg, response=response)

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -233,7 +233,7 @@ class AtlassianRestAPI(object):
         if self.advanced_mode:
             return response
 
-        response.raise_for_status()
+        self.raise_for_status(response)
         return response
 
     def get(
@@ -374,3 +374,13 @@ class AtlassianRestAPI(object):
         if self.advanced_mode or advanced_mode:
             return response
         return self._response_handler(response)
+
+    def raise_for_status(self, response):
+        """
+        Checks the response for errors and throws an exception if return code >= 400
+        Since different tools (Atlassian, Jira, ...) have different formats of returned json,
+        this method is intended to be overwritten by a tool specific implementation.
+        :param response:
+        :return:
+        """
+        response.raise_for_status()

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 import logging
 
+from requests import HTTPError
+
 from .rest_client import AtlassianRestAPI
 
 log = logging.getLogger(__name__)
@@ -763,3 +765,18 @@ class ServiceDesk(AtlassianRestAPI):
         url = "rest/servicedeskapi/servicedesk/{}/requesttype".format(service_desk_id)
 
         return self.post(url, headers=self.experimental_headers, data=data)
+
+    def raise_for_status(self, response):
+        """
+        Checks the response for an error status and raises an exception with the error message provided by the server
+        :param response:
+        :return:
+        """
+        if 400 <= response.status_code < 600:
+            try:
+                j = response.json()
+                error_msg = j["errorMessage"]
+            except Exception:
+                response.raise_for_status()
+
+            raise HTTPError(error_msg, response=response)


### PR DESCRIPTION
When the server returns a 4xx or 5xx status code and provides an
error message, that error message will be the message of the exception raised.