### PR TITLE
[BITBUCKET] Allow users to use filter on pipeline

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pipelines.py
+++ b/atlassian/bitbucket/cloud/repositories/pipelines.py
@@ -59,7 +59,7 @@ class Pipelines(BitbucketCloudBase):
 
         return self.__get_object(self.post(None, trailing=True, data=data))
 
-    def each(self, q=None, sort=None):
+    def each(self, q=None, sort=None, pagelen=None, page=None):
         """
         Returns the list of pipelines in this repository.
 
@@ -73,6 +73,10 @@ class Pipelines(BitbucketCloudBase):
         API docs: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/#get
         """
         params = {}
+        if page is not None:
+            params["page"] = page
+        if pagelen is not None:
+            params["pagelen"] = pagelen
         if sort is not None:
             params["sort"] = sort
         if q is not None:

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -279,8 +279,11 @@ Pipelines management
         # Get the repository first
         r = cloud.workspaces.get(workspace).repositories.get(repository)
 
-        # Get all Pipelines results for repository
+        # Get first ten Pipelines results for repository
         r.pipelines.each()
+
+        # Get twenty last Pipelines results for repository
+        r.pipelines.each(sort="-created_on", pagelen=20)
 
         # Trigger default Pipeline on the latest revision of the master branch
         r.pipelines.trigger()


### PR DESCRIPTION
Adding filter "page" & "pagelen" on pipeline.each()
This can allow to use workaround on #740 as mention in https://jira.atlassian.com/browse/BCLOUD-13806