### PR TITLE
Removed trailing slash from api call for get_tests

### DIFF
--- a/atlassian/xray.py
+++ b/atlassian/xray.py
@@ -18,7 +18,7 @@ class Xray(AtlassianRestAPI):
         :param test_keys: list of tests (eg. `['TEST-001', 'TEST-002']`) to retrieve.
         :return: Returns the retrieved tests.
         """
-        url = "rest/raven/1.0/api/test/?keys={0}".format(";".join(test_keys))
+        url = "rest/raven/1.0/api/test?keys={0}".format(";".join(test_keys))
         return self.get(url)
 
     def get_test_statuses(self):


### PR DESCRIPTION
Per issue #597, this api call should not have a trailing slash according to Xray documentation.