### PR TITLE
[BitBucket] Extend repo create method with is_private and fork_policy.

### DIFF
--- a/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/TestRepositoryCreated/POST
+++ b/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/TestRepositoryCreated/POST
@@ -80,10 +80,10 @@ responses['{"scm": "git"}'] = {
         "uuid": "{TestWorkspace1}",
     },
 }
-responses['{"scm": "git", "project": {"key": "TEST1"}}'] = {
+responses['{"scm": "git", "project": {"key": "TEST1"}, "fork_policy": "allow_forks"}'] = {
     "created_on": "2020-11-03T12:09:39.418592+00:00",
     "description": "Test newly created repository in project TEST1",
-    "fork_policy": "no_forks",
+    "fork_policy": "allow_forks",
     "full_name": "TestWorkspace1/TestRepositoryCreated",
     "has_issues": True,
     "has_wiki": False,

--- a/tests/test_bitbucket_cloud.py
+++ b/tests/test_bitbucket_cloud.py
@@ -1,4 +1,5 @@
 # coding: utf8
+from atlassian.bitbucket.cloud.repositories import WorkspaceRepositories
 import pytest
 import sys
 from datetime import datetime
@@ -48,10 +49,10 @@ class TestBasic:
     def test_create_repositories(self):
         result = CLOUD.workspaces.get("TestWorkspace1").repositories.create("TestRepositoryCreated")
         assert result.description == "Test newly created repository", "Result of repositories [create(...)]"
-        result = CLOUD.workspaces.get("TestWorkspace1").repositories.create("TestRepositoryCreated", "TEST1")
-        assert (
-            result.description == "Test newly created repository in project TEST1"
-        ), "Result of repositories [create(...)] with project"
+        result = CLOUD.workspaces.get("TestWorkspace1").repositories.create(
+            "TestRepositoryCreated", "TEST1", fork_policy=WorkspaceRepositories.ALLOW_FORKS
+        )
+        assert result.fork_policy == "allow_forks", "Result of repositories [create(...)] with project and fork policy"
 
     def test_get_repositories(self):
         result = [x["name"] for x in BITBUCKET.get_repositories("TestWorkspace1")]


### PR DESCRIPTION
Extend create functionas mentioned in https://github.com/atlassian-api/atlassian-python-api/pull/772#issuecomment-836199368. Instead of using kwargs only the option needed at creation time are added.