### PR TITLE
Fix Pylint failing with AttributeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ line-length = 120
 include_trailing_comma = false
 include = '(atlassian|examples|tests)\/.*(\.py|GET|POST)'
 
-[tool.pylint]
+[tool.pylint.format]
 max-line-length = 120
 
 [tool.pylint.MASTER]
@@ -21,7 +21,7 @@ max-line-length = 120
 extension-pkg-whitelist=''
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=10.0
+fail-under='10.0'
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.


### PR DESCRIPTION
Running *pylint* fails with `AttributeError`s:

```
AttributeError: 'int' object has no attribute 'items'
AttributeError: 'float' object has no attribute 'find'
```

Adding the section as shown in https://github.com/PyCQA/pylint/issues/3181#issuecomment-846129966 fixed the first error.

The second one is caused by floats not being handled correctly (fix but unreleased; https://github.com/PyCQA/pylint/issues/4518).

- Tested with 91ddbe2 (latest master commit)
- **Pylint:** 2.8.3
- **Python:** 3.9.5