### PR TITLE
[JIRA] Optimize error msg

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -3844,7 +3844,7 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         if 400 <= response.status_code < 600:
             try:
                 j = response.json()
-                error_msg = "\n".join(j['errorMessages'] + [k + ": " + v for k, v in j['errors'].items()])
+                error_msg = "\n".join(j["errorMessages"] + [k + ": " + v for k, v in j["errors"].items()])
             except Exception:
                 response.raise_for_status()
 

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -3844,7 +3844,7 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         if 400 <= response.status_code < 600:
             try:
                 j = response.json()
-                error_msg = "\n".join(j["errorMessages"])
+                error_msg = "\n".join(j['errorMessages'] + [k + ": " + v for k, v in j['errors'].items()])
             except Exception:
                 response.raise_for_status()
 


### PR DESCRIPTION
In some cases, the http api response's "errorMessages" is empty, like this:

`{'errorMessages': [], 'errors': {'fixVersions': 'data was not an array'}}`

appending the errors to the error message is better.