### PR TITLE
Fix TOML parsing error in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ suggestion-mode='yes'
 unsafe-load-any-extension='no'
 
 
-['tool.pylint.MESSAGES CONTROL']
+[tool.pylint."MESSAGES CONTROL"]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.


### PR DESCRIPTION
TOML Kit [ends up creating duplicate table names](https://github.com/sdispater/tomlkit/issues/138) and [TOML Lint](https://www.toml-lint.com/) flags this line as invalid. The TOML Kit failure makes it so `atlassian-python-api` [can't be installed via Poetry](https://github.com/python-poetry/poetry/issues/4278).