### PR TITLE
[Bitbucket] Adding ability to fork a repo to a different project

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -855,6 +855,23 @@ class Bitbucket(BitbucketBase):
             body["project"] = {"key": project_key}
         return self.post(url, data=body)
 
+    def fork_repository_new_project(self, project_key, repository_slug,
+                                    new_project, new_repository_slug):
+        """
+        Forks a repository to a separate project.
+        :param project_key: Origin Project Key
+        :param repository_slug: Origin repository slug
+        :param new_project_key: Project Key of target project
+        :param new_repository_slug: Target Repository slug
+        :return:
+        """
+        url = self._url_repo(project_key, repository_slug)
+        body = {}
+        if new_repository_slug is not None and new_project_key is not None:
+            body["name"] = new_repository_slug
+            body["project"] = {"key": new_project_key}
+        return self.post(url, data=body)
+
     def repo_keys(self, project_key, repo_key, start=0, limit=None, filter_str=None):
         """
         Get SSH access keys added to the repository

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -855,7 +855,7 @@ class Bitbucket(BitbucketBase):
             body["project"] = {"key": project_key}
         return self.post(url, data=body)
 
-    def fork_repository_new_project(self, project_key, repository_slug, new_project, new_repository_slug):
+    def fork_repository_new_project(self, project_key, repository_slug, new_project_key, new_repository_slug):
         """
         Forks a repository to a separate project.
         :param project_key: Origin Project Key

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -855,8 +855,7 @@ class Bitbucket(BitbucketBase):
             body["project"] = {"key": project_key}
         return self.post(url, data=body)
 
-    def fork_repository_new_project(self, project_key, repository_slug,
-                                    new_project, new_repository_slug):
+    def fork_repository_new_project(self, project_key, repository_slug, new_project, new_repository_slug):
         """
         Forks a repository to a separate project.
         :param project_key: Origin Project Key


### PR DESCRIPTION
Adding ability to fork a repo to a different project that differs from the original source project, which is what the existing
functionality is limited to.

Within a fair few of my workflows and projects I work with, we need to fork the original project to a personal user repo make changes and create pull requests back. Unfortunately in trying to automate these I'm limited in the ability of using this library to be able to bootstrap the workflow.

This is doing the bare minimum fork without adding in any extra properties like fork syncing etc to add the smallest change first that matches the existing mono-project fork.