### PR TITLE
[bitbucket pipelines] allow commit arg to be optional when only pattern is passed in pipeline trigger api

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pipelines.py
+++ b/atlassian/bitbucket/cloud/repositories/pipelines.py
@@ -23,9 +23,6 @@ class Pipelines(BitbucketCloudBase):
         2. Specific commit on a branch (additionally specify ``commit``)
         3. Specific pipeline (additionally specify ``pattern``)
 
-        Atleast one of ``commit`` or ``branch`` has to be provided.
-
-
         Variables has to be a list of dictionaries:
 
         {
@@ -45,9 +42,6 @@ class Pipelines(BitbucketCloudBase):
                 "ref_name": branch,
             },
         }
-
-        if not commit and not pattern:
-            raise ValueError("[commit] and [pattern] both cannot by empty!")
 
         if commit is not None:
             data["target"]["commit"] = {

--- a/atlassian/bitbucket/cloud/repositories/pipelines.py
+++ b/atlassian/bitbucket/cloud/repositories/pipelines.py
@@ -23,6 +23,9 @@ class Pipelines(BitbucketCloudBase):
         2. Specific commit on a branch (additionally specify ``commit``)
         3. Specific pipeline (additionally specify ``pattern``)
 
+        Atleast one of ``commit`` or ``branch`` has to be provided.
+
+
         Variables has to be a list of dictionaries:
 
         {
@@ -42,14 +45,16 @@ class Pipelines(BitbucketCloudBase):
                 "ref_name": branch,
             },
         }
+
+        if not commit and not pattern:
+            raise ValueError("[commit] and [pattern] both cannot by empty!")
+
         if commit is not None:
             data["target"]["commit"] = {
                 "type": "commit",
                 "hash": commit,
             }
         if pattern is not None:
-            if commit is None:
-                raise ValueError("Missing argument [commit].")
             data["target"]["selector"] = {
                 "type": "custom",
                 "pattern": pattern,

--- a/atlassian/bitbucket/cloud/repositories/pipelines.py
+++ b/atlassian/bitbucket/cloud/repositories/pipelines.py
@@ -21,7 +21,7 @@ class Pipelines(BitbucketCloudBase):
 
         1. Latest revision of a branch (specify ``branch``)
         2. Specific commit on a branch (additionally specify ``commit``)
-        3. Specific pipeline (additionally specify ``pattern``)
+        3. Specific pipeline (additionally specify ``pattern``. ``commit`` is optional here)
 
         Variables has to be a list of dictionaries:
 
@@ -42,7 +42,6 @@ class Pipelines(BitbucketCloudBase):
                 "ref_name": branch,
             },
         }
-
         if commit is not None:
             data["target"]["commit"] = {
                 "type": "commit",


### PR DESCRIPTION
Fixes Issue : https://github.com/atlassian-api/atlassian-python-api/issues/847