### PR TITLE
[Bitbucket] Removing redundant double check for simpler code to read (minor/readability)

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -851,7 +851,6 @@ class Bitbucket(BitbucketBase):
         body = {}
         if new_repository_slug is not None:
             body["name"] = new_repository_slug
-        if new_repository_slug is not None:
             body["project"] = {"key": project_key}
         return self.post(url, data=body)
 


### PR DESCRIPTION
Two concurrent if statements that check the same thing, instead of double checking the code, just nesting both statements within the same identical conditional