### PR TITLE
Jira: Add support for authentication through access token

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -51,7 +51,7 @@ class AtlassianRestAPI(object):
         kerberos=None,
         cloud=False,
         proxies=None,
-        token=None
+        token=None,
     ):
         self.url = url
         self.username = username

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -51,6 +51,7 @@ class AtlassianRestAPI(object):
         kerberos=None,
         cloud=False,
         proxies=None,
+        token=None
     ):
         self.url = url
         self.username = username
@@ -69,6 +70,8 @@ class AtlassianRestAPI(object):
             self._session = session
         if username and password:
             self._create_basic_session(username, password)
+        elif token is not None:
+            self._create_token_session(token)
         elif oauth is not None:
             self._create_oauth_session(oauth)
         elif oauth2 is not None:
@@ -86,6 +89,9 @@ class AtlassianRestAPI(object):
 
     def _create_basic_session(self, username, password):
         self._session.auth = (username, password)
+
+    def _create_token_session(self, token):
+        self._update_header("Authorization", "Bearer {token}".format(token=token))
 
     def _create_kerberos_session(self, _):
         from requests_kerberos import HTTPKerberosAuth, OPTIONAL

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,6 +152,19 @@ Or reuse cookie file:
         url='http://localhost:8080',
         cookies=cookie_dict)
 
+Or using Personal Access Token
+Note: this method is valid for Jira Data center / server editions only! For Jira cloud, see below.
+
+First, create your access token (check https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html for details)
+Then, just provide the token to the constructor:
+
+.. code-block:: python
+
+   jira = Jira(
+       url='https://your-jira-instance.company.com',
+       token=jira_access_token
+   )
+
 To authenticate to the Atlassian Cloud APIs Jira, Confluence, ServiceDesk:
 
 .. code-block:: python


### PR DESCRIPTION
Jira Server v8.14 introduces authentication through a [Personnal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html), which is different from the existing cloud authentication.
It works through a simple "Authorization: Bearer <token>" header.

This PR add support for this authentication mechanism.
Tested on Jira server v8.14.1 