### PR TITLE
change: allow editor=v1 as a parameter of the create_page function

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -632,8 +632,8 @@ class Confluence(AtlassianRestAPI):
         }
         if parent_id:
             data["ancestors"] = [{"type": type, "id": parent_id}]
-        if editor == "v2":
-            data["metadata"] = {"properties": {"editor": {"value": "v2"}}}
+        if editor is not None and editor in ["v1", "v2"]:
+            data["metadata"] = {"properties": {"editor": {"value": editor}}}
         try:
             response = self.post(url, data=data)
         except HTTPError as e:


### PR DESCRIPTION
The editor= parameter of the confluence.create_page API will accept 'v1' as well as 'v2' by this change.
The editor='v1' works both in confluence.create_page() and confluence.update_or_create() APIs.

Background:
- The 'v1' parameter is required to make a copy of the existing Confluence page which expects old (v1) editor
to maintain the appearance of the page.
