### PR TITLE
Fix missing data when using pullRequests.each()

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pullRequests.py
+++ b/atlassian/bitbucket/cloud/repositories/pullRequests.py
@@ -72,7 +72,7 @@ class PullRequests(BitbucketCloudBase):
         if q is not None:
             params["q"] = q
         for pr in self._get_paged(None, trailing=True, params=params):
-            yield self.__get_object(pr)
+            yield self.__get_object(super(PullRequests, self).get(pr.get("id")))
 
         return
 

--- a/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/GET
+++ b/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/GET
@@ -1,0 +1,343 @@
+responses[None
+] = {
+    "rendered": {
+        "description": {
+            "raw": "PRDescription",
+            "markup": "markdown",
+            "html": "<p>PRDescription</p>",
+            "type": "rendered",
+        },
+        "title": {
+            "raw": "PRTitle",
+            "markup": "markdown",
+            "html": "<p>PRTitle</p>",
+            "type": "rendered"
+        },
+    },
+    "type": "pullrequest",
+    "description": "PRDescription",
+    "links": {
+        "decline": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/decline"
+        },
+        "diffstat": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/diffstat/TestWorkspace1/testrepository1:16182c4698fb%0D1fbd047cd123?from_pullrequest_id=25"
+        },
+        "commits": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/commits"
+        },
+        "self": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25"
+        },
+        "comments": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/comments"
+        },
+        "merge": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/merge"
+        },
+        "html": {
+            "href": "https://bitbucket.org/TestWorkspace1/testrepository1/pull-requests/25"
+        },
+        "activity": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/activity"
+        },
+        "request-changes": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/request-changes"
+        },
+        "diff": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/diff/TestWorkspace1/testrepository1:16182c4698fb%0D1fbd047cd123?from_pullrequest_id=25"
+        },
+        "approve": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/approve"
+        },
+        "statuses": {
+            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/statuses"
+        },
+    },
+    "title": "PRTitle",
+    "close_source_branch": true,
+    "reviewers": [
+        {
+            "display_name": "User04DisplayName",
+            "uuid": "{User04UUID}",
+            "links": {
+                "self": {
+                    "href": "users/%7BUser04UUID%7D"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7BUser04UUID%7D/"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU4-2.png"
+                },
+            },
+            "nickname": "User04Nickname",
+            "type": "user",
+            "account_id": "User04AccountID",
+        },
+        {
+            "display_name": "User02DisplayName",
+            "uuid": "{User02UUID}",
+            "links": {
+                "self": {
+                    "href": "users/%7BUser02UUID%7D"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7BUser02UUID%7D/"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU2-3.png"
+                },
+            },
+            "nickname": "User02Nickname",
+            "type": "user",
+            "account_id": "User02AccountID",
+        },
+        {
+            "display_name": "User01DisplayName",
+            "uuid": "{User01UUID}",
+            "links": {
+                "self": {
+                    "href": "users/%7BUser01UUID%7D"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7BUser01UUID%7D/"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU1-3.png"
+                },
+            },
+            "nickname": "User01Nickname",
+            "type": "user",
+            "account_id": "User01AccountID",
+        },
+    ],
+    "id": 25,
+    "destination": {
+        "commit": {
+            "hash": "1fbd047cd99a",
+            "type": "commit",
+            "links": {
+                "self": {
+                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/1fbd047cd99a"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/1fbd047cd99a"
+                },
+            },
+        },
+        "repository": {
+            "links": {
+                "self": {
+                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1"
+                },
+                "avatar": {
+                    "href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"
+                },
+            },
+            "type": "repository",
+            "name": "testrepository1",
+            "full_name": "TestWorkspace1/testrepository1",
+            "uuid": "{RepoUUID}",
+        },
+        "branch": {
+            "name": "master"
+        },
+    },
+    "created_on": "2020-03-19T12:00:03.494356+00:00",
+    "summary": {
+        "raw": "PRDescription",
+        "markup": "markdown",
+        "html": "<p>PRDescription</p>",
+        "type": "rendered"
+    },
+    "source": {
+        "commit": {
+            "hash": "16182c4123fb",
+            "type": "commit",
+            "links": {
+                "self": {
+                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/16182c4123fb"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/16182c4123fb"
+                },
+            },
+        },
+        "repository": {
+            "links": {
+                "self": {
+                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1"
+                },
+                "avatar": {
+                    "href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"
+                },
+            },
+            "type": "repository",
+            "name": "testrepository1",
+            "full_name": "TestWorkspace1/testrepository1",
+            "uuid": "{RepoUUID}",
+        },
+        "branch": {
+            "name": "feature/test-branch"
+        },
+    },
+    "comment_count": 5,
+    "state": "OPEN",
+    "task_count": 0,
+    "participants": [
+        {
+            "participated_on": "2020-03-19T14:29:24.928709+00:00",
+            "state": null,
+            "role": "PARTICIPANT",
+            "user": {
+                "display_name": "User05DisplayName",
+                "uuid": "{User05UUID}",
+                "links": {
+                    "self": {
+                        "href": "users/%7BUser05UUID%7D"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/%7BUser05UUID%7D/"
+                    },
+                    "avatar": {
+                        "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2U5-5.png"
+                    },
+                },
+                "nickname": "User05Nickname",
+                "type": "user",
+                "account_id": "User05AccountID",
+            },
+            "type": "participant",
+            "approved": false,
+        },
+        {
+            "participated_on": "2020-07-09T07:00:54.416331+00:00",
+            "state": null,
+            "role": "PARTICIPANT",
+            "user": {
+                "display_name": "User03DisplayName",
+                "uuid": "{User03UUID}",
+                "links": {
+                    "self": {
+                        "href": "users/%7BUser03UUID%7D"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/%7BUser03UUID%7D/"
+                    },
+                    "avatar": {
+                        "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU3-0.png"
+                    },
+                },
+                "nickname": "User03Nickname",
+                "type": "user",
+                "account_id": "User03AccountID",
+            },
+            "type": "participant",
+            "approved": false,
+        },
+        {
+            "participated_on": "2020-12-27T14:09:14.660262+00:00",
+            "state": "approved",
+            "role": "REVIEWER",
+            "user": {
+                "display_name": "User04DisplayName",
+                "uuid": "{User04UUID}",
+                "links": {
+                    "self": {
+                        "href": "users/%7BUser04UUID%7D"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/%7BUser04UUID%7D/"
+                    },
+                    "avatar": {
+                        "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU4-2.png"
+                    },
+                },
+                "nickname": "User04Nickname",
+                "type": "user",
+                "account_id": "User04AccountID",
+            },
+            "type": "participant",
+            "approved": true,
+        },
+        {
+            "participated_on": "2020-12-27T14:05:58.999476+00:00",
+            "state": "changes_requested",
+            "role": "REVIEWER",
+            "user": {
+                "display_name": "User01DisplayName",
+                "uuid": "{User01UUID}",
+                "links": {
+                    "self": {
+                        "href": "users/%7BUser01UUID%7D"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/%7BUser01UUID%7D/"
+                    },
+                    "avatar": {
+                        "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU1-3.png"
+                    },
+                },
+                "nickname": "User01Nickname",
+                "type": "user",
+                "account_id": "User01AccountID",
+            },
+            "type": "participant",
+            "approved": false,
+        },
+        {
+            "participated_on": null,
+            "state": null,
+            "role": "REVIEWER",
+            "user": {
+                "display_name": "User02DisplayName",
+                "uuid": "{User02UUID}",
+                "links": {
+                    "self": {
+                        "href": "users/%7BUser02UUID%7D"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/%7BUser02UUID%7D/"
+                    },
+                    "avatar": {
+                        "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU2-3.png"
+                    },
+                },
+                "nickname": "User02Nickname",
+                "type": "user",
+                "account_id": "User02AccountID",
+            },
+            "type": "participant",
+            "approved": false,
+        },
+    ],
+    "reason": "",
+    "updated_on": "2020-12-27T14:09:14.660262+00:00",
+    "author": {
+        "display_name": "User03DisplayName",
+        "uuid": "{User03UUID}",
+        "links": {
+            "self": {
+                "href": "users/%7BUser03UUID%7D"
+            },
+            "html": {
+                "href": "https://bitbucket.org/%7BUser03UUID%7D/"
+            },
+            "avatar": {
+                "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU3-0.png"
+            },
+        },
+        "nickname": "User03Nickname",
+        "type": "user",
+        "account_id": "User03AccountID",
+    },
+    "merge_commit": null,
+    "closed_by": null,
+}

--- a/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/GET
+++ b/tests/responses/bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/GET
@@ -1,5 +1,4 @@
-responses[None
-] = {
+responses[None] = {
     "rendered": {
         "description": {
             "raw": "PRDescription",
@@ -7,37 +6,22 @@ responses[None
             "html": "<p>PRDescription</p>",
             "type": "rendered",
         },
-        "title": {
-            "raw": "PRTitle",
-            "markup": "markdown",
-            "html": "<p>PRTitle</p>",
-            "type": "rendered"
-        },
+        "title": {"raw": "PRTitle", "markup": "markdown", "html": "<p>PRTitle</p>", "type": "rendered"},
     },
     "type": "pullrequest",
     "description": "PRDescription",
     "links": {
-        "decline": {
-            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/decline"
-        },
+        "decline": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/decline"},
         "diffstat": {
             "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/diffstat/TestWorkspace1/testrepository1:16182c4698fb%0D1fbd047cd123?from_pullrequest_id=25"
         },
-        "commits": {
-            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/commits"
-        },
-        "self": {
-            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25"
-        },
+        "commits": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/commits"},
+        "self": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25"},
         "comments": {
             "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/comments"
         },
-        "merge": {
-            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/merge"
-        },
-        "html": {
-            "href": "https://bitbucket.org/TestWorkspace1/testrepository1/pull-requests/25"
-        },
+        "merge": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/merge"},
+        "html": {"href": "https://bitbucket.org/TestWorkspace1/testrepository1/pull-requests/25"},
         "activity": {
             "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/activity"
         },
@@ -47,9 +31,7 @@ responses[None
         "diff": {
             "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/diff/TestWorkspace1/testrepository1:16182c4698fb%0D1fbd047cd123?from_pullrequest_id=25"
         },
-        "approve": {
-            "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/approve"
-        },
+        "approve": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/approve"},
         "statuses": {
             "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/pullrequests/25/statuses"
         },
@@ -61,12 +43,8 @@ responses[None
             "display_name": "User04DisplayName",
             "uuid": "{User04UUID}",
             "links": {
-                "self": {
-                    "href": "users/%7BUser04UUID%7D"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/%7BUser04UUID%7D/"
-                },
+                "self": {"href": "users/%7BUser04UUID%7D"},
+                "html": {"href": "https://bitbucket.org/%7BUser04UUID%7D/"},
                 "avatar": {
                     "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU4-2.png"
                 },
@@ -79,12 +57,8 @@ responses[None
             "display_name": "User02DisplayName",
             "uuid": "{User02UUID}",
             "links": {
-                "self": {
-                    "href": "users/%7BUser02UUID%7D"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/%7BUser02UUID%7D/"
-                },
+                "self": {"href": "users/%7BUser02UUID%7D"},
+                "html": {"href": "https://bitbucket.org/%7BUser02UUID%7D/"},
                 "avatar": {
                     "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU2-3.png"
                 },
@@ -97,12 +71,8 @@ responses[None
             "display_name": "User01DisplayName",
             "uuid": "{User01UUID}",
             "links": {
-                "self": {
-                    "href": "users/%7BUser01UUID%7D"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/%7BUser01UUID%7D/"
-                },
+                "self": {"href": "users/%7BUser01UUID%7D"},
+                "html": {"href": "https://bitbucket.org/%7BUser01UUID%7D/"},
                 "avatar": {
                     "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU1-3.png"
                 },
@@ -118,75 +88,46 @@ responses[None
             "hash": "1fbd047cd99a",
             "type": "commit",
             "links": {
-                "self": {
-                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/1fbd047cd99a"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/1fbd047cd99a"
-                },
+                "self": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/1fbd047cd99a"},
+                "html": {"href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/1fbd047cd99a"},
             },
         },
         "repository": {
             "links": {
-                "self": {
-                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1"
-                },
-                "avatar": {
-                    "href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"
-                },
+                "self": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"},
+                "html": {"href": "https://bitbucket.org/TestWorkspace1/testrepository1"},
+                "avatar": {"href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"},
             },
             "type": "repository",
             "name": "testrepository1",
             "full_name": "TestWorkspace1/testrepository1",
             "uuid": "{RepoUUID}",
         },
-        "branch": {
-            "name": "master"
-        },
+        "branch": {"name": "master"},
     },
     "created_on": "2020-03-19T12:00:03.494356+00:00",
-    "summary": {
-        "raw": "PRDescription",
-        "markup": "markdown",
-        "html": "<p>PRDescription</p>",
-        "type": "rendered"
-    },
+    "summary": {"raw": "PRDescription", "markup": "markdown", "html": "<p>PRDescription</p>", "type": "rendered"},
     "source": {
         "commit": {
             "hash": "16182c4123fb",
             "type": "commit",
             "links": {
-                "self": {
-                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/16182c4123fb"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/16182c4123fb"
-                },
+                "self": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1/commit/16182c4123fb"},
+                "html": {"href": "https://bitbucket.org/TestWorkspace1/testrepository1/commits/16182c4123fb"},
             },
         },
         "repository": {
             "links": {
-                "self": {
-                    "href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"
-                },
-                "html": {
-                    "href": "https://bitbucket.org/TestWorkspace1/testrepository1"
-                },
-                "avatar": {
-                    "href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"
-                },
+                "self": {"href": "bitbucket/cloud/2.0/repositories/TestWorkspace1/testrepository1"},
+                "html": {"href": "https://bitbucket.org/TestWorkspace1/testrepository1"},
+                "avatar": {"href": "https://bytebucket.org/ravatar/%7BRepoUUID%7D?ts=default"},
             },
             "type": "repository",
             "name": "testrepository1",
             "full_name": "TestWorkspace1/testrepository1",
             "uuid": "{RepoUUID}",
         },
-        "branch": {
-            "name": "feature/test-branch"
-        },
+        "branch": {"name": "feature/test-branch"},
     },
     "comment_count": 5,
     "state": "OPEN",
@@ -200,12 +141,8 @@ responses[None
                 "display_name": "User05DisplayName",
                 "uuid": "{User05UUID}",
                 "links": {
-                    "self": {
-                        "href": "users/%7BUser05UUID%7D"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/%7BUser05UUID%7D/"
-                    },
+                    "self": {"href": "users/%7BUser05UUID%7D"},
+                    "html": {"href": "https://bitbucket.org/%7BUser05UUID%7D/"},
                     "avatar": {
                         "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2U5-5.png"
                     },
@@ -225,12 +162,8 @@ responses[None
                 "display_name": "User03DisplayName",
                 "uuid": "{User03UUID}",
                 "links": {
-                    "self": {
-                        "href": "users/%7BUser03UUID%7D"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/%7BUser03UUID%7D/"
-                    },
+                    "self": {"href": "users/%7BUser03UUID%7D"},
+                    "html": {"href": "https://bitbucket.org/%7BUser03UUID%7D/"},
                     "avatar": {
                         "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU3-0.png"
                     },
@@ -250,12 +183,8 @@ responses[None
                 "display_name": "User04DisplayName",
                 "uuid": "{User04UUID}",
                 "links": {
-                    "self": {
-                        "href": "users/%7BUser04UUID%7D"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/%7BUser04UUID%7D/"
-                    },
+                    "self": {"href": "users/%7BUser04UUID%7D"},
+                    "html": {"href": "https://bitbucket.org/%7BUser04UUID%7D/"},
                     "avatar": {
                         "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU4-2.png"
                     },
@@ -275,12 +204,8 @@ responses[None
                 "display_name": "User01DisplayName",
                 "uuid": "{User01UUID}",
                 "links": {
-                    "self": {
-                        "href": "users/%7BUser01UUID%7D"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/%7BUser01UUID%7D/"
-                    },
+                    "self": {"href": "users/%7BUser01UUID%7D"},
+                    "html": {"href": "https://bitbucket.org/%7BUser01UUID%7D/"},
                     "avatar": {
                         "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU1-3.png"
                     },
@@ -300,12 +225,8 @@ responses[None
                 "display_name": "User02DisplayName",
                 "uuid": "{User02UUID}",
                 "links": {
-                    "self": {
-                        "href": "users/%7BUser02UUID%7D"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/%7BUser02UUID%7D/"
-                    },
+                    "self": {"href": "users/%7BUser02UUID%7D"},
+                    "html": {"href": "https://bitbucket.org/%7BUser02UUID%7D/"},
                     "avatar": {
                         "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU2-3.png"
                     },
@@ -324,12 +245,8 @@ responses[None
         "display_name": "User03DisplayName",
         "uuid": "{User03UUID}",
         "links": {
-            "self": {
-                "href": "users/%7BUser03UUID%7D"
-            },
-            "html": {
-                "href": "https://bitbucket.org/%7BUser03UUID%7D/"
-            },
+            "self": {"href": "users/%7BUser03UUID%7D"},
+            "html": {"href": "https://bitbucket.org/%7BUser03UUID%7D/"},
             "avatar": {
                 "href": "https://secure.gravatar.com/avatar/ad2424dafaasdssaew12232344434432?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU3-0.png"
             },

--- a/tests/test_bitbucket_cloud_oo.py
+++ b/tests/test_bitbucket_cloud_oo.py
@@ -313,6 +313,7 @@ class TestPullRequests:
         assert isinstance(prs[0], PullRequest)
         assert prs[0].id == 1
         assert prs[1].id == 25
+        assert len(list(prs[1].participants())) == 5
 
     def test_create(self, tc2):
         reviewers = ["{User04UUID}", "{User02UUID}", "{User01UUID}"]


### PR DESCRIPTION
This fixes a bug that ends in missing data when using `pullRequests.each()`.

The pullrequests endpoint won't deliver the 
whole PullRequest object (e.g. participants, reviewers missing).
So we need to load all the data for the PR object.

The [docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests) say:
> The list of users that were added as reviewers on this pull request when it was created. **For performance reasons, the API only includes this list on a pull request's self URL.**

After merging this PR the PullRequest API is still broken and needs to be fixed by #844 
