### PR TITLE
[JIRA] Add method to get an issue's edit meta

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -758,7 +758,7 @@ class Jira(AtlassianRestAPI):
             params["expand"] = expand
         url = "rest/api/2/issue/createmeta?projectKeys={}".format(project)
         return self.get(url, params=params)
-    
+
     def issue_editmeta(self, key):
         base_url = self.resource_url("issue")
         url = f"{base_url}/{key}/editmeta"

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -758,6 +758,11 @@ class Jira(AtlassianRestAPI):
             params["expand"] = expand
         url = "rest/api/2/issue/createmeta?projectKeys={}".format(project)
         return self.get(url, params=params)
+    
+    def issue_editmeta(self, key):
+        base_url = self.resource_url("issue")
+        url = f"{base_url}/{key}/editmeta"
+        return self.get(url)
 
     def get_issue_changelog(self, issue_key):
         """

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -203,7 +203,7 @@ Manage issues
 
     # Get Issue Link
     jira.get_issue_link(link_id)
-    
+
     # Get Issue Edit Meta
     jira.issue_editmeta(issue_key)
 

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -203,6 +203,9 @@ Manage issues
 
     # Get Issue Link
     jira.get_issue_link(link_id)
+    
+    # Get Issue Edit Meta
+    jira.issue_editmeta(issue_key)
 
     # Create Issue Link
     data = {


### PR DESCRIPTION
add an issue_editmeta method to Jira, (similar to the existing issue_createmeta) only for issues which already exist. 