### PR TITLE
Add functionality to delete a watcher from an issue

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -963,6 +963,21 @@ class Jira(AtlassianRestAPI):
             data=data,
         )
 
+    def issue_delete_watcher(self, issue_key, user):
+        """
+        Stop watching issue
+        :param issue_key:
+        :param user:
+        :return:
+        """
+        log.warning('Deleting user {user} from "{issue_key}" watchers'.format(issue_key=issue_key, user=user))
+        data = user
+        base_url = self.resource_url("issue")
+        return self.delete(
+            "{base_url}/{issue_key}/watchers".format(base_url=base_url, issue_key=issue_key),
+            data=data,
+        )
+
     def assign_issue(self, issue, account_id=None):
         """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.
         :param issue: the issue ID or key to assign

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -233,6 +233,12 @@ Manage issues
     # Export Issues to csv
     jira.csv(jql, all_fields=False)
 
+    # Add watcher to an issue
+    jira.issue_add_watcher(issue_key, user)
+
+    # Remove watcher from an issue
+    jira.issue_delete_watcher(issue_key, user)
+
 
 Manage Boards
 -------------


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

adds `issue_delete_watcher` function.