### PR TITLE
Fix delete watchers

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -971,11 +971,11 @@ class Jira(AtlassianRestAPI):
         :return:
         """
         log.warning('Deleting user {user} from "{issue_key}" watchers'.format(issue_key=issue_key, user=user))
-        data = user
+        params = {"username": user}
         base_url = self.resource_url("issue")
         return self.delete(
             "{base_url}/{issue_key}/watchers".format(base_url=base_url, issue_key=issue_key),
-            data=data,
+            params=params,
         )
 
     def assign_issue(self, issue, account_id=None):


### PR DESCRIPTION
Unlike in add watcher, the user parameter has to be handed over as query parameter, according to the documentation: https://docs.atlassian.com/software/jira/docs/api/REST/8.13.14/#issue-removeWatcher. This patch fixes this issue.