### PR TITLE
[Jira] document assign_issue() usage for Jira Server

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1099,7 +1099,8 @@ class Jira(AtlassianRestAPI):
         """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.
         :param issue: the issue ID or key to assign
         :type issue: int or str
-        :param account_id: the account ID of the user to assign the issue to
+        :param account_id: the account ID of the user to assign the issue to;
+                for jira server the value for account_id should be a valid jira username
         :type account_id: str
         :rtype: bool
         """


### PR DESCRIPTION
## Context

Documentation for ```account_id``` parameter for ```assign_issue()``` is misleading for usage with ****Jira Server****.

## Fix: Update Method Documentation 

When using Jira Server; ```assign_issue()```'s ```account_id``` parameter must take a valid Jira ````username````.

The parameter does  ****NOT**** take  a Jira Cloud ```account_id``` or Jira Server ```user_id``` as current docs for this project suggest when using Jira Server.

Reference materials for endpoint ```assign_issue()``` calls for Jira Server can be found [here](https://docs.atlassian.com/software/jira/docs/api/REST/8.5.0/#api/2/issue-assign).

### Example 
```python
 assign_issue(issue_key="EXAMPLE-1234", account_id="mzuckerberg")
``` 

Method documentation has been updated to avoid future confusion.

