### PR TITLE
Use paged get for get_branch_permission.

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2328,7 +2328,7 @@ class Bitbucket(BitbucketBase):
         :return:
         """
         url = self._url_branches_permissions(project_key, permission_id, repository_slug)
-        return self.get(url)
+        return self._get_paged(url)
 
     def all_branches_permissions(self, project_key, permission_id, repository_slug=None):
         """

--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -67,8 +67,11 @@ class BitbucketBase(AtlassianRestAPI):
                 url = response.get("next")
                 if url is None:
                     break
-                # From now on we have absolute URLs including the trailing slash if needed
+                # From now on we have absolute URLs with parameters
                 absolute = True
+                # Params are now provided by the url
+                params = {}
+                # Trailing should not be added as it is already part of the url
                 trailing = False
             else:
                 if response.get("nextPageStart") is None:


### PR DESCRIPTION
Also the changes from #872 are merged into the copied code.

@gonchik What about switching all functions using the paged API to the `_get_paged` function. With this the parameters can be removed, but this will be a incompatible change. 

Closes #933