### PR TITLE
[Confluence] Add `_get_paged` function for internal handling of paged APIs.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest
 pytest-cov
 flake8
 flake8-no-fstring
-black
+black==21.12b0
 tox
 coverage
 codecov

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = pylint {[base]linting_targets}
 [testenv:black]
 basepython = python3
 skip_install = true
-deps = black
+deps = black==21.12b0
 commands = black --check --diff {[base]linting_targets}
 
 [testenv:mypy]


### PR DESCRIPTION
As suggested in #936 this PR adds a function to handle the paging.

ATTENTION: I've no instance to test it, it's only created from the API documentation. @hograthm or @gonchik can you test this?If it's working other calls of confluence can also be changed.