### PR TITLE
Fix paging when querying Jira via JQL

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2023,7 +2023,7 @@ class Bitbucket(BitbucketBase):
             params["avatarScheme"] = avatar_scheme
         if limit:
             params["limit"] = limit
-        return (self.get(url, params=params) or {}).get("values")
+        return self._get_paged(url, params=params)
 
     def _url_commit(self, project_key, repository_slug, commit_id, api_root=None, api_version=None):
         return "{}/{}".format(

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2590,8 +2590,6 @@ class Jira(AtlassianRestAPI):
         :return:
         """
         params = {}
-        if start is not None:
-            params["startAt"] = int(start)
         if limit is not None:
             params["maxResults"] = int(limit)
         if fields is not None:
@@ -2605,7 +2603,24 @@ class Jira(AtlassianRestAPI):
         if validate_query is not None:
             params["validateQuery"] = validate_query
         url = self.resource_url("search")
-        return self.get(url, params=params)
+
+        results = []
+        while True:
+            params["startAt"] = int(start)
+            response = self.get(url, params=params)
+            if not response:
+                break
+
+            issues = response["issues"]
+            results.extend(issues)
+            total = int(response["total"])
+            # #print("DBG: response: total={total} start={startAt} max={maxResults}".format(**response))
+            # If we don't have a limit, and there's more to fetch, keep looping
+            if limit is not None or total <= len(response["issues"]) + start:
+                break
+            start += len(issues)
+
+        return results
 
     def csv(self, jql, limit=1000, all_fields=True, start=None, delimiter=None):
         """


### PR DESCRIPTION
It seems that, probably by accident, the `Jira.jql` method doesn't check for paging and, as a result, only returns the first page. This makes it properly retrieve all the pages.

We've been using this patch at my workplace for a while already, but I haven't opened a PR before due to being busy (lazy).
I'm not sure how to run the tests, or how to validate it with "black" as in the contributing instructions, please let me know if I need to fix something.