### PR TITLE
Jira: Fix user properties endpoints (use account id)

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1532,52 +1532,51 @@ class Jira(AtlassianRestAPI):
         url = self.resource_url("user")
         return self.post(url, data=data)
 
-    def user_properties(self, username):
+    def user_properties(self, account_id):
         """
         Get user property
-        :param username:
+        :param account_id:
         :return:
         """
         base_url = self.resource_url("user/properties")
-        url = "{base_url}?username={username}".format(base_url=base_url, username=username)
+        url = "{base_url}?accountId={account_id}".format(base_url=base_url, account_id=account_id)
         return self.get(url)
 
-    def user_property(self, username, key_property):
+    def user_property(self, account_id, key_property):
         """
         Get user property
+        :param account_id:
         :param key_property:
-        :param username:
         :return:
         """
-        params = {"username": username}
+        params = {"accountId": account_id}
         base_url = self.resource_url("user/properties")
         return self.get("{base_url}/{key_property}".format(base_url=base_url, key_property=key_property), params=params)
 
-    def user_set_property(self, username, key_property, value_property):
+    def user_set_property(self, account_id, key_property, value_property):
         """
         Set property for user
-        :param username:
+        :param account_id:
         :param key_property:
         :param value_property:
         :return:
         """
         base_url = self.resource_url("user/properties")
-        url = "{base_url}/{key_property}?username={user_name}".format(
-            base_url=base_url, key_property=key_property, user_name=username
+        url = "{base_url}/{key_property}?accountId={account_id}".format(
+            base_url=base_url, key_property=key_property, account_id=account_id
         )
-        data = {"value": value_property}
-        return self.put(url, data=data)
+        return self.put(url, data=value_property)
 
-    def user_delete_property(self, username, key_property):
+    def user_delete_property(self, account_id, key_property):
         """
         Delete property for user
-        :param username:
+        :param account_id:
         :param key_property:
         :return:
         """
         base_url = self.resource_url("user/properties")
         url = "{base_url}/{key_property}".format(base_url=base_url, key_property=key_property)
-        params = {"username": username}
+        params = {"accountId": account_id}
         return self.delete(url, params=params)
 
     def user_update_or_create_property_through_rest_point(self, username, key, value):


### PR DESCRIPTION
According to https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-properties/#api-group-user-properties, the user identifier for user property endpoints is "accountId", not "username".

This fixes the API for the endpoints:
- Get user property keys
- Get user property
- Set user property
- Delete user property