### PR TITLE
DOC : correct URL for black tool in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,7 +34,7 @@ Mandatory conditions
 
 Please follow the code style in the docs.
 
-.. _black:  https://black.readthedocs.io/en/stable/editor_integration.html
+.. _black:  https://black.readthedocs.io/en/stable/integrations/editors.html
 
 Connect on Chat for any queries
 ---------------------------------


### PR DESCRIPTION
Hi,

I try to add some changes but one URL in the contributing file was wrong.
Probably a change from black maintainers.
