### PR TITLE
updated get_file_list method for folder support

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2200,7 +2200,6 @@ class Bitbucket(BitbucketBase):
             params["limit"] = limit
         return self._get_paged(url, params=params)
 
-
     def get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
         """
         Retrieve the raw content for a file path at a specified revision.

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2166,7 +2166,7 @@ class Bitbucket(BitbucketBase):
         data.update(report_params)
         return self.put(url, data=data)
 
-    def get_file_list(self, project_key, repository_slug, query=None, start=0, limit=None):
+    def get_file_list(self, project_key, repository_slug, sub_folder=None, query=None, start=0, limit=None):
         """
         Retrieve a page of files from particular directory of a repository.
         The search is done recursively, so all files from any sub-directory of the specified directory will be returned.
@@ -2174,12 +2174,15 @@ class Bitbucket(BitbucketBase):
         :param start:
         :param project_key:
         :param repository_slug:
+        :param sub_folder: a sub folder in the target repository to list the files from.
         :param query: the commit ID or ref (e.g. a branch or tag) to list the files at.
                       If not specified the default branch will be used instead.
         :param limit: OPTIONAL
         :return:
         """
         url = "{}/files".format(self._url_repo(project_key, repository_slug))
+        if sub_folder:
+            url = "{}/{}".format(url, sub_folder)
         params = {}
         if query:
             params["at"] = query

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2166,7 +2166,15 @@ class Bitbucket(BitbucketBase):
         data.update(report_params)
         return self.put(url, data=data)
 
-    def get_file_list(self, project_key, repository_slug, sub_folder=None, query=None, start=0, limit=None):
+    def get_file_list(
+        self,
+        project_key,
+        repository_slug,
+        sub_folder=None,
+        query=None,
+        start=0,
+        limit=None,
+    ):
         """
         Retrieve a page of files from particular directory of a repository.
         The search is done recursively, so all files from any sub-directory of the specified directory will be returned.
@@ -2191,6 +2199,7 @@ class Bitbucket(BitbucketBase):
         if limit:
             params["limit"] = limit
         return self._get_paged(url, params=params)
+
 
     def get_content_of_file(self, project_key, repository_slug, filename, at=None, markup=None):
         """

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2182,7 +2182,7 @@ class Bitbucket(BitbucketBase):
         """
         url = "{}/files".format(self._url_repo(project_key, repository_slug))
         if sub_folder:
-            url = "{}/{}".format(url, sub_folder)
+            url = "{}/{}".format(url, sub_folder.lstrip("/"))
         params = {}
         if query:
             params["at"] = query


### PR DESCRIPTION
To only list files from a specific folder in the target repository, you can add it to the URL like so:
`.../projects/{project_key}/repos/{repository_slug}/files/{folder}

I added an extra parameter to the method, which will add the folder to the URL if given.