### PR TITLE
Fix error response without 'errors' field

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -392,7 +392,7 @@ class AtlassianRestAPI(object):
         if 400 <= response.status_code < 600:
             try:
                 j = response.json()
-                error_msg = "\n".join(j["errorMessages"] + [k + ": " + v for k, v in j["errors"].items()])
+                error_msg = "\n".join(j.get("errorMessages", list()) + [k + ": " + v for k, v in j.get("errors", dict()).items()])
             except Exception:
                 response.raise_for_status()
             else:


### PR DESCRIPTION
Our Jira cloud instance does not include "errors" field in some error responses:
```
{'errorMessages': ["The value 'ABC' does not exist for the field 'project'."], 'warningMessages': []}
```
This crashes the error processing with `KeyError: 'errors'`, and the client doesn't see the _actual_ error message.