### PR TITLE
Make pagination work for fetching subpages of confluence page

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -76,8 +76,8 @@ class Confluence(AtlassianRestAPI):
             url = response.get("_links", {}).get("next")
             if url is None:
                 break
-            # From now on we have absolute URLs with parameters
-            absolute = True
+            # From now on we have relative URLs with parameters
+            absolute = False
             # Params are now provided by the url
             params = {}
             # Trailing should not be added as it is already part of the url


### PR DESCRIPTION
Fixes: https://github.com/atlassian-api/atlassian-python-api/issues/989

When a page has more than 25 subpages, the method get_child_id_list and similar are throwing an exception about wrong URL (missing domain).

This is caused by the fact that` _get_paged` method is setting `absolute = True` where it should be `absolute = False`
As according to documentation the `_links.next` page URL is relative (the domain is returned in `_links.base` field in the response.