### PR TITLE
[Confluence] remove content history

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1367,7 +1367,7 @@ class Confluence(AtlassianRestAPI):
         :param version_number: version number
         :return:
         """
-        url = "rest/experimental/content/{id}/version/{versionNumber}".format(id=page_id, versionNumber=version_number)
+        url = "rest/api/content/{id}/version/{versionNumber}".format(id=page_id, versionNumber=version_number)
         self.delete(url)
 
     def remove_page_history(self, page_id, version_number):


### PR DESCRIPTION
It seems like the confluence rest api has been updated. this pull request fixes the remove content history url.
https://developer.atlassian.com/cloud/confluence/rest/api-group-content-versions/#api-wiki-rest-api-content-id-version-versionnumber-get