### PR TITLE
Jira : add account_id to the parameters of add_user_to_group for Jira Cloud 

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -759,17 +759,27 @@ class Jira(AtlassianRestAPI):
         params["maxResults"] = limit
         return self.get(url, params=params)
 
-    def add_user_to_group(self, username, group_name):
+    def add_user_to_group(self, username=None, group_name=None, account_id=None):
         """
         Add given user to a group
 
+        For Jira DC/Server platform
         :param username: str
+        :param group_name: str
+        :return: Current state of the group
+
+        For Jira Cloud platform
+        :param account_id: str (name is no longer available for Jira Cloud platform)
         :param group_name: str
         :return: Current state of the group
         """
         url = self.resource_url("group/user")
         params = {"groupname": group_name}
-        data = {"name": username}
+        url_domain = self.url
+        if "atlassian.net" in url_domain:
+            data = {"accountId": account_id}
+        else:
+            data = {"name": username}
         return self.post(url, params=params, data=data)
 
     def remove_user_from_group(self, username=None, group_name=None, account_id=None):

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -69,7 +69,7 @@ Manage groups
     jira.get_all_users_from_group(group, include_inactive_users=False, start=0, limit=50)
 
     # Add given user to a group
-    jira.add_user_to_group(username, group_name)
+    jira.add_user_to_group(username=None, group_name=None, account_id=None)
 
     # Remove given user from a group
     jira.remove_user_from_group(username=None, group_name=None, account_id=None)


### PR DESCRIPTION
This PR is to add account_id to the parameters of add_user_to_group for Jira Cloud. Username of the parameters is no longer available for Jira Cloud. When the site url contains Jira Cloud one, account_id is used for the parameter. This PR is add version of this PR https://github.com/atlassian-api/atlassian-python-api/pull/1018 . For DC/Server users, there is nothing to change.