### PR TITLE
Add new createmeta functions to comply with Jira 9 API

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import logging
 import re
-from typing import Union
 from warnings import warn
 
 from requests import HTTPError
@@ -918,7 +917,7 @@ class Jira(AtlassianRestAPI):
             query_result, missing_issues = self.bulk_issue(issue_list, fields)
         return query_result, missing_issues
 
-    def issue_createmeta(self, project: str, expand="projects.issuetypes.fields"):
+    def issue_createmeta(self, project, expand="projects.issuetypes.fields"):
         """
         This function is deprecated.
         See https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
@@ -933,15 +932,17 @@ class Jira(AtlassianRestAPI):
         params = {}
         if expand:
             params["expand"] = expand
-        url = "rest/api/2/issue/createmeta?projectKeys={}".format(project)
+        url = self.resource_url("issue/createmeta?projectKeys={}".format(project))
         return self.get(url, params=params)
 
-    def issue_createmeta_issuetypes(self, project: str):
-        url = "rest/api/2/issue/createmeta/{}/issuetypes".format(project)
+    def issue_createmeta_issuetypes(self, project):
+        url = self.resource_url("issue/createmeta/{}/issuetypes".format(project))
         return self.get(url)
 
-    def issue_createmeta_fieldtypes(self, project: str, issue_type_id: Union[str, int]):
-        url = "rest/api/2/issue/createmeta/{}/issuetypes/{}".format(project, issue_type_id)
+    def issue_createmeta_fieldtypes(self, project, issue_type_id):
+        url = self.resource_url(
+            "issue/createmeta/{}/issuetypes/{}".format(project, issue_type_id)
+        )
         return self.get(url)
 
     def issue_editmeta(self, key):

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 import logging
 import re
+from typing import Union
+from warnings import warn
 
 from requests import HTTPError
 
@@ -916,12 +918,28 @@ class Jira(AtlassianRestAPI):
             query_result, missing_issues = self.bulk_issue(issue_list, fields)
         return query_result, missing_issues
 
-    def issue_createmeta(self, project, expand="projects.issuetypes.fields"):
+    def issue_createmeta(self, project: str, expand="projects.issuetypes.fields"):
+        """
+        This function is deprecated.
+        See https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
+        for further details.
+        """
+        warn("This function will fail from Jira 9+. "
+             "Use issue_createmeta_issuetypes or issue_createmeta_fieldtypes instead.",
+             DeprecationWarning, stacklevel=2)
         params = {}
         if expand:
             params["expand"] = expand
         url = "rest/api/2/issue/createmeta?projectKeys={}".format(project)
         return self.get(url, params=params)
+
+    def issue_createmeta_issuetypes(self, project: str):
+        url = "rest/api/2/issue/createmeta/{}/issuetypes".format(project)
+        return self.get(url)
+
+    def issue_createmeta_fieldtypes(self, project: str, issue_type_id: Union[str, int]):
+        url = "rest/api/2/issue/createmeta/{}/issuetypes/{}".format(project, issue_type_id)
+        return self.get(url)
 
     def issue_editmeta(self, key):
         base_url = self.resource_url("issue")

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -924,9 +924,12 @@ class Jira(AtlassianRestAPI):
         See https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
         for further details.
         """
-        warn("This function will fail from Jira 9+. "
-             "Use issue_createmeta_issuetypes or issue_createmeta_fieldtypes instead.",
-             DeprecationWarning, stacklevel=2)
+        warn(
+            "This function will fail from Jira 9+. "
+            "Use issue_createmeta_issuetypes or issue_createmeta_fieldtypes instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         params = {}
         if expand:
             params["expand"] = expand

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -940,9 +940,7 @@ class Jira(AtlassianRestAPI):
         return self.get(url)
 
     def issue_createmeta_fieldtypes(self, project, issue_type_id):
-        url = self.resource_url(
-            "issue/createmeta/{}/issuetypes/{}".format(project, issue_type_id)
-        )
+        url = self.resource_url("issue/createmeta/{}/issuetypes/{}".format(project, issue_type_id))
         return self.get(url)
 
     def issue_editmeta(self, key):


### PR DESCRIPTION
This PR closes #1030 

Adds new functions to maintain the same level of functionality, while also adding a deprecation warning for the old function.

To learn more about why this is needed, check out https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html

TODO:
- May be best to use the `self.resource_url` function for consistency's sake