### PR TITLE
Jira: Add ability to add icons to issue remote links

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1321,7 +1321,9 @@ class Jira(AtlassianRestAPI):
             url += "/" + internal_id
         return self.get(url, params=params)
 
-    def create_or_update_issue_remote_links(self, issue_key, link_url, title, global_id=None, relationship=None):
+    def create_or_update_issue_remote_links(
+        self, issue_key, link_url, title, global_id=None, relationship=None, icon_url=None, icon_title=None
+    ):
         """
         Add Remote Link to Issue, update url if global_id is passed
         :param issue_key: str
@@ -1329,6 +1331,8 @@ class Jira(AtlassianRestAPI):
         :param title: str
         :param global_id: str, OPTIONAL:
         :param relationship: str, OPTIONAL: Default by built-in method: 'Web Link'
+        :param icon_url: str, OPTIONAL: Link to a 16x16 icon representing the type of the object in the remote system
+        :param icon_title: str, OPTIONAL: Text for the tooltip of the main icon describing the type of the object in the remote system
         """
         base_url = self.resource_url("issue")
         url = "{base_url}/{issue_key}/remotelink".format(base_url=base_url, issue_key=issue_key)
@@ -1337,6 +1341,13 @@ class Jira(AtlassianRestAPI):
             data["globalId"] = global_id
         if relationship:
             data["relationship"] = relationship
+        if icon_url or icon_title:
+            icon_data = {}
+            if icon_url:
+                icon_data["url16x16"] = icon_url
+            if icon_title:
+                icon_data["title"] = icon_title
+            data["icon"] = icon_data
         return self.post(url, data=data)
 
     def get_issue_remote_link_by_id(self, issue_key, link_id):

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -229,7 +229,7 @@ Manage issues
     jira.remove_issue_link(link_id)
 
     # Create or Update Issue Remote Links
-    jira.create_or_update_issue_remote_links(issue_key, link_url, title, global_id=None, relationship=None)
+    jira.create_or_update_issue_remote_links(issue_key, link_url, title, global_id=None, relationship=None, icon_url=None, icon_title=None)
 
     # Get Issue Remote Link by link ID
     jira.get_issue_remote_link_by_id(issue_key, link_id)


### PR DESCRIPTION
Adds two parameters to `Jira.create_or_update_issue_remote_links` to support adding icons to remote links:
```
    "object": {                                            
        "url":"example.com/support?id=1",     
        "title":"TSTSUP-111",                                 
        "icon": {                                         
            "url16x16":"https://example.com/favicon.png",    
            "title":"Support Ticket"   
        },
```

see descriptions of these fields [here](https://developer.atlassian.com/server/jira/platform/using-fields-in-remote-issue-links/).