### PR TITLE
[Jira] Add function get_user_groups

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1821,6 +1821,17 @@ class Jira(AtlassianRestAPI):
     Reference: https://docs.atlassian.com/software/jira/docs/api/REST/8.5.0/#api/2/project
     """
 
+    def get_user_groups(self, account_id=None):
+        """
+        Get groups of a user
+        This API is only available for Jira Cloud platform
+        :param account_id: str
+        :return: list of group info
+        """
+        params = {"accountId": account_id}
+        url = self.resource_url("user/groups")
+        return self.get(url, params=params)
+
     def get_all_projects(self, included_archived=None, expand=None):
         return self.projects(included_archived, expand)
 

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -51,6 +51,9 @@ Manage users
     # Fuzzy search using emailAddress or displayName
     jira.user_find_by_user_string(query, start=0, limit=50, include_inactive_users=False)
 
+    # Get groups of a user. This API is only available for Jira Cloud platform.
+    jira.get_user_groups(account_id)
+
 Manage groups
 -------------
 


### PR DESCRIPTION
Hi

This PR adds function get_user_groups which is only available for Jira Cloud platform. Jira DC/Server doesn't have this API.

Thanks