### PR TITLE
Fix AttributeError: 'Response' object has no attribute 'get'

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -492,7 +492,7 @@ class ServiceDesk(AtlassianRestAPI):
         experimental_headers["X-Atlassian-Token"] = "no-check"
 
         with open(filename, "rb") as file:
-            result = self.post(path=url, headers=experimental_headers, files={"file": file}).get("temporaryAttachments")
+            result = self.post(path=url, headers=experimental_headers, files={"file": file}).json().get("temporaryAttachments")
             temp_attachment_id = result[0].get("temporaryAttachmentId")
 
             return temp_attachment_id


### PR DESCRIPTION
Adds the missing `.json()` Response method in order to _transform_ the response object into a python dictionary.