### PR TITLE
Move API from experimental to normal url (#960)

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1357,7 +1357,7 @@ class Confluence(AtlassianRestAPI):
         :param version_number:
         :return:
         """
-        url = "rest/experimental/content/{0}/version/{1}".format(content_id, version_number)
+        url = "rest/api/content/{id}/version/{versionNumber}".format(id=content_id, versionNumber=version_number)
         return self.get(url)
 
     def remove_content_history(self, page_id, version_number):

--- a/docs/confluence.rst
+++ b/docs/confluence.rst
@@ -258,7 +258,7 @@ Other actions
     # Get page history
     confluence.history(page_id)
 
-    # Get content history by version number. It works as experimental method
+    # Get content history by version number
     confluence.get_content_history_by_version_number(content_id, version_number)
 
     # Remove content history. It works as experimental method


### PR DESCRIPTION
On Confluence cloud, the experimental API for `get_content_history_by_version_number` does not work. By changing `rest/experimental/content/` to `rest/api/content/`, it works normally.

Fixes #960 raised by @yvespelle