### PR TITLE
Fix getting of cloud commit

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/commits.py
+++ b/atlassian/bitbucket/cloud/repositories/commits.py
@@ -70,7 +70,7 @@ class Commit(BitbucketCloudBase):
     @property
     def message(self):
         """Commit message."""
-        return self.get_data("title")
+        return self.get_data("message")
 
     @property
     def date(self):

--- a/atlassian/bitbucket/cloud/repositories/commits.py
+++ b/atlassian/bitbucket/cloud/repositories/commits.py
@@ -35,7 +35,7 @@ class Commits(BitbucketCloudBase):
         if q is not None:
             params["q"] = q
         for commit in self._get_paged(top, trailing=True, params=params):
-            yield self.__get_object(super(Commits, self).get(commit.get("hash")))
+            yield self.get(commit.get("hash"))
 
     def get(self, commit_hash):
         """


### PR DESCRIPTION
The function `Commits.each` uses the wrong URL `https://api.bitbucket.org/2.0/repositories/{workspace}/{repo}/commits/{commit}` in the `yield` expression. Here the `Commits.get` must be used with the commit hash as argument.


Closes #1071 