### PR TITLE
Python 2.7 compatibility

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -369,7 +369,7 @@ class Bamboo(AtlassianRestAPI):
             elements_key="results",
             element_key="result",
             label=label,
-            **params,
+            **params
         )
 
     def latest_results(

--- a/atlassian/bitbucket/cloud/repositories/__init__.py
+++ b/atlassian/bitbucket/cloud/repositories/__init__.py
@@ -254,7 +254,7 @@ class Repository(BitbucketCloudBase):
         self.__commits = Commits(
             "{}/commits".format(self.url),
             data={"links": {"commit": {"href": "{}/commit".format(self.url)}}},
-            **self._new_session_args,
+            **self._new_session_args
         )
         self.__default_reviewers = DefaultReviewers("{}/default-reviewers".format(self.url), **self._new_session_args)
         self.__issues = Issues("{}/issues".format(self.url), **self._new_session_args)

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -3,7 +3,10 @@ import logging
 from json import dumps
 
 import requests
-from oauthlib.oauth1 import SIGNATURE_RSA_SHA512
+try:
+    from oauthlib.oauth1 import SIGNATURE_RSA_SHA512 as SIGNATURE_RSA
+except ImportError:
+    from oauthlib.oauth1 import SIGNATURE_RSA_SHA512
 from requests import HTTPError
 from requests_oauthlib import OAuth1, OAuth2
 from six.moves.urllib.parse import urlencode
@@ -103,7 +106,7 @@ class AtlassianRestAPI(object):
         oauth = OAuth1(
             oauth_dict["consumer_key"],
             rsa_key=oauth_dict["key_cert"],
-            signature_method=SIGNATURE_RSA_SHA512,
+            signature_method=SIGNATURE_RSA,
             resource_owner_key=oauth_dict["access_token"],
             resource_owner_secret=oauth_dict["access_token_secret"],
         )


### PR DESCRIPTION
As long as Python 2.7 support is maintained, it should at least be importable without  SyntaxErrors, even if full functional testing is not part of the CI. 