### PR TITLE
Returned _link details for next loop

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -511,7 +511,7 @@ class Confluence(AtlassianRestAPI):
 
             raise
 
-        return response.get("results")
+        return response
 
     def get_all_pages_from_space_trash(self, space, start=0, limit=500, status="trashed", content_type="page"):
         """


### PR DESCRIPTION
To get all the all the pages need to pass all the details related to next traversal 