### PR TITLE
[Bitbucket Cloud] Add support for query parameters in pullrequest.comments endpoint

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pullRequests.py
+++ b/atlassian/bitbucket/cloud/repositories/pullRequests.py
@@ -275,13 +275,19 @@ class PullRequest(BitbucketCloudBase):
 
         return
 
-    def comments(self):
+    def comments(self, q=None):
         """
         Returns generator object of the comments endpoint
 
+        :param q: string: Query string to narrow down the response.
+                          See https://developer.atlassian.com/bitbucket/api/2/reference/meta/filtering for details.
+
         API docs: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests/%7Bpull_request_id%7D/comments#get
         """
-        for comment in self._get_paged("comments"):
+        params = {}
+        if q is not None:
+            params["q"] = q
+        for comment in self._get_paged("comments", params=params):
             yield Comment(comment, **self._new_session_args)
 
     def comment(self, raw_message):

--- a/atlassian/bitbucket/cloud/repositories/pullRequests.py
+++ b/atlassian/bitbucket/cloud/repositories/pullRequests.py
@@ -275,16 +275,20 @@ class PullRequest(BitbucketCloudBase):
 
         return
 
-    def comments(self, q=None):
+    def comments(self, q=None, sort=None):
         """
         Returns generator object of the comments endpoint
 
         :param q: string: Query string to narrow down the response.
-                          See https://developer.atlassian.com/bitbucket/api/2/reference/meta/filtering for details.
+        :param sort: string: Name of a response property to sort results.
+            See https://developer.atlassian.com/bitbucket/api/2/reference/meta/filtering
+            for details on filtering and sorting.
 
         API docs: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests/%7Bpull_request_id%7D/comments#get
         """
         params = {}
+        if sort is not None:
+            params["sort"] = sort
         if q is not None:
             params["q"] = q
         for comment in self._get_paged("comments", params=params):


### PR DESCRIPTION
Closes [this issue](https://github.com/atlassian-api/atlassian-python-api/issues/1100).

Updated `pull_requests.comments` to accept optional query string and sort parameters, which are added to `params` if present and used with `_get_paged`.
Logic was copied from `PullRequests.each`, which already accepts query string and sort parameters.