### PR TITLE
[Jira] Issues for Backlog updated URL

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -4221,7 +4221,7 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         """
         :param board_id: int, str
         """
-        url = "rest/agile/1.0/{board_id}/backlog".format(board_id=board_id)
+        url = "rest/agile/1.0/board/{board_id}/backlog".format(board_id=board_id)
         return self.get(url)
 
     def get_issues_for_board(self, board_id, jql, fields="*all", start=0, limit=None, expand=None):


### PR DESCRIPTION
Issues for backlog is using the incorrect URL according to this documentation: 
* https://docs.atlassian.com/jira-software/REST/7.0.4/#agile/1.0/board-getIssuesForBacklog
* https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-backlog-get resulting in HTTP 404

Fixes: _#1103_
