### PR TITLE
[Bamboo] Enable/disable elastic bamboo configuration

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -1200,6 +1200,22 @@ class Bamboo(AtlassianRestAPI):
         resource = "elasticConfiguration/{configuration_id}".format(configuration_id=configuration_id)
         return self.delete(self.resource_url(resource))
 
+    def get_elastic_bamboo(self):
+        """
+        Get elastic bamboo configuration
+        :return:
+        """
+        response = self.get("rest/admin/latest/elastic/config")
+        return response
+
+    def set_elastic_bamboo(self, data):
+        """
+        Set elastic bamboo configuration
+        :return:
+        """
+        response = self.put("rest/admin/latest/elastic/config", data=data)
+        return response
+
     def get_plugins_info(self):
         """
         Provide plugins info

--- a/docs/bamboo.rst
+++ b/docs/bamboo.rst
@@ -276,3 +276,12 @@ Elastic Bamboo
     # Delete elastic bamboo configuration
     delete_elastic_configuration('123456')
 
+    # Get elastic bamboo configuration
+    get_elastic_bamboo()
+
+    # Set elastic bamboo configuration
+    set_elastic_bamboo({"enabled": True, "awsCredentialsType": "INSTANCE_PROFILE", "region": "ASIA_PACIFIC_SE_2",
+    "privateKeyFile": "", "certificateFile": "", "maxNumOfElasticInstances": 1, "allocatePublicIpToVpcInstances": False,
+    "elasticInstanceManagement": {"type": "Disabled"}, "uploadAwsAccountIdentifierToElasticInstances": False,
+    "elasticAutoTermination": { "enabled": True, "shutdownDelay": 300}})
+


### PR DESCRIPTION
Atlassian introduced 2 endpoints to enable and disable elastic bamboo

`Get admin latest elastic config
GET /rest/admin/latest/elastic/config`

`Put admin latest elastic config
PUT /rest/admin/latest/elastic/config`