### PR TITLE
Fix API url for getting objecttype attributes

### DIFF
--- a/atlassian/insight.py
+++ b/atlassian/insight.py
@@ -565,7 +565,7 @@ class Insight(AtlassianRestAPI):
         params.update({k: v for k, v in kwargs if v is not None and k not in ["self", "type_id"]})
 
         return self.get(
-            "{0}objecttype/{1}/attributes".format(self.api_root, type_id),
+            "{0}/objecttype/{1}/attributes".format(self.api_root, type_id),
             headers=self.experimental_headers,
             params=params,
         )


### PR DESCRIPTION
Hi!
I get an error when trying to get objecttype attributes via this lib.
The was occurred because of invalid link generation - just miss a slash in generated url:
https://jira.insight.url/rest/insight/1.0objecttype/1/attributes'