### PR TITLE
Alias get_organizations

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -323,10 +323,10 @@ class ServiceDesk(AtlassianRestAPI):
                 params=params,
             )
         return self.get(url_with_sd_id, headers=self.experimental_headers, params=params)
-    
+
     # add alias for spelling consistency
     get_organizations = get_organisations
-    
+
     def get_organization(self, organization_id):
         """
         Get an organization for a given organization ID

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -323,7 +323,10 @@ class ServiceDesk(AtlassianRestAPI):
                 params=params,
             )
         return self.get(url_with_sd_id, headers=self.experimental_headers, params=params)
-
+    
+    # add alias for spelling consistency
+    get_organizations = get_organisations
+    
     def get_organization(self, organization_id):
         """
         Get an organization for a given organization ID

--- a/tests/test_servicedesk.py
+++ b/tests/test_servicedesk.py
@@ -1,6 +1,7 @@
 # coding: utf8
-import pytest
 import sys
+
+import pytest
 
 from atlassian import ServiceDesk
 
@@ -25,6 +26,10 @@ class TestBasic:
         result = [x["name"] for x in SERVICEDESK.get_organisations()["values"]]
         assert result == ["Charlie Cakes Franchises"], "Result of [get_organisations()]"
 
+    def test_get_organizations(self):
+        result = [x["name"] for x in SERVICEDESK.get_organizations()["values"]]
+        assert result == ["Charlie Cakes Franchises"], "Result of [get_organizations()]"
+
     def test_get_organisations_servicedesk_id(self):
         result = [x["name"] for x in SERVICEDESK.get_organisations(service_desk_id="{serviceDeskId}")["values"]]
         assert result == [
@@ -32,6 +37,14 @@ class TestBasic:
             "Atlas Coffee Co",
             "The Adjustment Bureau",
         ], "Result of [get_organisations(service_desk_id)]"
+
+    def test_get_organizations_servicedesk_id(self):
+        result = [x["name"] for x in SERVICEDESK.get_organizations(service_desk_id="{serviceDeskId}")["values"]]
+        assert result == [
+            "Charlie Cakes Franchises",
+            "Atlas Coffee Co",
+            "The Adjustment Bureau",
+        ], "Result of [get_organizations(service_desk_id)]"
 
     def test_get_organization(self):
         result = SERVICEDESK.get_organization("{organizationId}")


### PR DESCRIPTION
There's a spelling inconsistency of 'organisations'.  This PR adds `service_desk.get_organizations()` as an alias of `get_organisations()` to maintain compatibility while allowing for correct spelling.