### PR TITLE
[Enhancement] Add support for fetching id of blogpost

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -207,14 +207,15 @@ class Confluence(AtlassianRestAPI):
         """
         return self.get_page_child_by_type(page_id=page_id, type="page")
 
-    def get_page_id(self, space, title):
+    def get_page_id(self, space, title, type='page'):
         """
         Provide content id from search result by title and space
         :param space: SPACE key
         :param title: title
+        :param type: type of content: Page or Blogpost. Defaults to page
         :return:
         """
-        return (self.get_page_by_title(space, title) or {}).get("id")
+        return (self.get_page_by_title(space, title, type=type) or {}).get("id")
 
     def get_parent_content_id(self, page_id):
         """

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -269,7 +269,7 @@ class Confluence(AtlassianRestAPI):
         """
         return self.get_page_by_title(space, title, start, limit, expand)
 
-    def get_page_by_title(self, space, title, start=0, limit=1, expand=None):
+    def get_page_by_title(self, space, title, start=0, limit=1, expand=None, type='page'):
         """
         Returns the first page  on a piece of Content.
         :param space: Space key
@@ -278,12 +278,13 @@ class Confluence(AtlassianRestAPI):
         :param limit: OPTIONAL: The limit of the number of labels to return, this may be restricted by
                             fixed system limits. Default: 1.
         :param expand: OPTIONAL: expand e.g. history
+        :param type: OPTIONAL: Type of content: Page or Blogpost. Defaults to page
         :return: The JSON data returned from searched results the content endpoint, or the results of the
                  callback. Will raise requests.HTTPError on bad input, potentially.
                  If it has IndexError then return the None.
         """
         url = "rest/api/content"
-        params = {}
+        params = {"type": type}
         if start is not None:
             params["start"] = int(start)
         if limit is not None:


### PR DESCRIPTION
## Closes #1141 

Goal of this PR:

- Update `get_page_by_title` to support blogpost too.
- Update `get_page_by_id`  to support blogpost.

## Prereview Checklist

- [x] Tested the changes locally
