### PR TITLE
'description-file' will not be supported in future versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@ ignore_missing_imports = True
 test = pytest
 
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
**When installing  atlassian-python-api==3.35.0 (python version 3.9.6)**

**The following warning occurrend and prevented the following installing.** 

UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead

**Raw log like this:**

(.gitbot) [root@g]# pip install -r requirements.txt 
Collecting atlassian-python-api==3.35.0
  Downloading atlassian-python-api-3.35.0.tar.gz (144 kB)
     |████████████████████████████████| 144 kB 820 kB/s 
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /root/gitbot/.gitbot/bin/python3 /root/gitbot/.gitbot/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpwsc0qhv2
         cwd: /tmp/pip-install-ih1e8kl6/atlassian-python-api_894477325a7f4f6791cc58571f741000
    Complete output (65 lines):
    /tmp/pip-build-env-5wv7r6s7/overlay/lib/python3.9/site-packages/setuptools/dist.py:788: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
      warnings.warn(
    running dist_info

....