### PR TITLE
Add the possiblity to change the signature method

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -110,7 +110,7 @@ class AtlassianRestAPI(object):
         oauth = OAuth1(
             oauth_dict["consumer_key"],
             rsa_key=oauth_dict["key_cert"],
-            signature_method=oauth_dict.get("signature_method",SIGNATURE_RSA),
+            signature_method=oauth_dict.get("signature_method", SIGNATURE_RSA),
             resource_owner_key=oauth_dict["access_token"],
             resource_owner_secret=oauth_dict["access_token_secret"],
         )

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -110,7 +110,7 @@ class AtlassianRestAPI(object):
         oauth = OAuth1(
             oauth_dict["consumer_key"],
             rsa_key=oauth_dict["key_cert"],
-            signature_method=SIGNATURE_RSA,
+            signature_method=oauth_dict.get("signature_method",SIGNATURE_RSA),
             resource_owner_key=oauth_dict["access_token"],
             resource_owner_secret=oauth_dict["access_token_secret"],
         )


### PR DESCRIPTION
RSA_SHA512 was hardcoded in the REST Client for OAuth1. It is now possible to change the 'Signature Method' in the 'oauth_dict' with the key 'signature_method' to another signature. The default value is kept as 'SIGNATURE_RSA' if no value for the mentioned key is provided.