### PR TITLE
[Confluence]: PDF export function no longer working #1158 BUGFIX

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -2438,7 +2438,7 @@ class Confluence(AtlassianRestAPI):
                 log.error("Failed to get download PDF url.")
                 raise ApiNotFoundError("Failed to export page as PDF", reason="Failed to get download PDF url.")
             # To download the PDF file, the request should be with no headers of authentications.
-            return requests.get(url).content
+            return requests.get(url, timeout=75).content
         return self.get(url, headers=headers, not_json_response=True)
 
     def get_page_as_word(self, page_id):

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -2700,8 +2700,7 @@ class Confluence(AtlassianRestAPI):
                     time.sleep(3)
             log.debug("Task successfully done, querying the task result for the download url")
             # task result url starts with /wiki, remove it.
-            task_result_url = task_result_url[5:]
-            task_content = self.get(task_result_url, not_json_response=True)
+            task_content = self.get(task_result_url[5:], not_json_response=True)
             download_url = task_content.decode(encoding="utf-8", errors="strict")
             log.debug("Successfully got the download url")
             return download_url

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -2690,14 +2690,14 @@ class Confluence(AtlassianRestAPI):
                 if percentage_complete == 100:
                     running_task = False
                     log.info(f"Task completed - {task_state}")
-                    task_result_url = progress_response.get("result")
-                    log.debug("Extract task results to download PDF.")
-                    if not task_result_url or not task_result_url.startswith("/wiki/services/api/v1/download/pdf"):
+                    if task_state == "FAILED":
                         log.error("PDF conversion not successful.")
                         return None
+                    log.debug("Extract task results to download PDF.")
+                    task_result_url = progress_response.get("result")
                 else:
-                    time.sleep(3)
                     log.info(f"{percentage_complete}% - {task_state}")
+                    time.sleep(3)
             log.debug("Task successfully done, querying the task result for the download url")
             # task result url starts with /wiki, remove it.
             task_result_url = task_result_url[5:]


### PR DESCRIPTION
## #1158 bugix
TLDR; 
Atlassian recently updated Confluence's PDF export functionality.

**Here's the current flow works:**
1.  Create a pdf page export task using the `spaces/flyingpdf/pdfpageexport.action?pageId={pageId}` endpoint.
2. In the next step, use the poll endpoint, `runningtaskxml.action?taskId={taskId}`, to determine whether the export task has been completed.
3. Retrieve the download URL from the poll endpoint response if the task was successfully completed
4. Get the PDF data from the retrieved endpoint.

**Step 2 seems to be where the issue appears:**
- It does not matter if the task is successfully initialised or not, the poll endpoint will report that the task does not exist without raising an error message.
- As a result, step 3 queries the space URL without a specific page.
- Consequently, the response is a general HTML page without any error messages.

**The problems are as follows:**
- There seems to be a problem with the poll endpoint. Atlassian recently updated Confluence's PDF export functionality.
- An error should be thrown if the task ID is invalid.

**PR main changes**
**The functionality is working as expected**
- Atlassian recently updated Confluence's PDF export functionality. To get the export task's current state, `task/{taskId}/progress` endpoint should be used instead of the deprecated `runningtaskxml.action?taskId={taskId}`. 
- Also the flow of retrieving the content from the download signed URL was changed a bit.
In order to download a PDF file from a signed S3 URL, you do not need to provide any authentication or headers. If you do provide those, the request will fail. As the session has already been initiated with those headers, it cannot be used. Does it make sense to use the request library directly?
- **Feel free to edit and elaborate**