### PR TITLE
Fix #1154: add safety checks to parse 400 error responses

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -474,7 +474,11 @@ class AtlassianRestAPI(object):
                     error_msg = "\n".join([k + ": " + v for k, v in j.items()])
                 else:
                     error_msg = "\n".join(
-                        j.get("errorMessages", list()) + [k.get("message", "") for k in j.get("errors", dict())]
+                        j.get("errorMessages", list())
+                        + [
+                            k.get("message", "") if isinstance(k, dict) else v
+                            for k, v in j.get("errors", dict()).items()
+                        ]
                     )
             except Exception as e:
                 log.error(e)

--- a/tests/responses/jira/rest/api/2/issue/POST
+++ b/tests/responses/jira/rest/api/2/issue/POST
@@ -1,0 +1,5 @@
+responses['{"fields": {"issuetype": "foo", "summary": "summary", "project": "project"}}'] = {
+    "status_code": 400,
+    "errorMessages": [],
+    "errors": {"labels": "Field 'labels' cannot be set. It is not on the appropriate screen, or unknown."},
+}

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -44,3 +44,8 @@ class TestJira(TestCase):
         """Get comment on issue by id, but not found"""
         with self.assertRaises(HTTPError):
             self.jira.epic_issues("BAR-11")
+
+    def test_post_issue_with_invalid_request(self):
+        """Post an issue but receive a 400 error response"""
+        # with self.assertRaises(HTTPError):
+        self.jira.create_issue(fields={"issuetype": "foo", "summary": "summary", "project": "project"})


### PR DESCRIPTION
Since I don't know if the original code was supposed to support specific response bodies, I decided to keep the original behaviour and add safety checks for the responses that we receive from Jira in 400 responses.