### PR TITLE
Adds features to specify the target pipeline type.

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/pipelines.py
+++ b/atlassian/bitbucket/cloud/repositories/pipelines.py
@@ -17,7 +17,7 @@ class Pipelines(BitbucketCloudBase):
             **self._new_session_args,
         )
 
-    def trigger(self, branch="master", commit=None, pattern=None, variables=None):
+    def trigger(self, branch="master", type="custom", commit=None, pattern=None, variables=None):
         """
         Trigger a new pipeline. The following options are possible (1 and 2
         trigger the pipeline that the branch is associated with in the Pipelines
@@ -48,7 +48,7 @@ class Pipelines(BitbucketCloudBase):
         }
         if commit is not None:
             data["target"]["commit"] = {
-                "type": "commit",
+                "type": type,
                 "hash": commit,
             }
         if pattern is not None:


### PR DESCRIPTION
This PR enables custom target pipeline types when triggering the bitbucket cloud pipeline.  When the user needs to call a specific pipeline of a given branch.