### PR TITLE
confluence: correctly report a failed pdf-export

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -2723,12 +2723,12 @@ class Confluence(AtlassianRestAPI):
                 progress_response = self.get(poll_url)
                 percentage_complete = int(progress_response.get("progress", 0))
                 task_state = progress_response.get("state")
-                if percentage_complete == 100:
+                if task_state == "FAILED":
+                    log.error("PDF conversion not successful.")
+                    return None
+                elif percentage_complete == 100:
                     running_task = False
                     log.info("Task completed - {task_state}".format(task_state=task_state))
-                    if task_state == "FAILED":
-                        log.error("PDF conversion not successful.")
-                        return None
                     log.debug("Extract task results to download PDF.")
                     task_result_url = progress_response.get("result")
                 else:


### PR DESCRIPTION
The Code in `get_pdf_download_url_for_confluence_cloud` checks for errors in the PDF Export like this:

```
                if percentage_complete == 100:
                    running_task = False
                    log.info("Task completed - {task_state}".format(task_state=task_state))
                    if task_state == "FAILED":
                        log.error("PDF conversion not successful.")
                        return None
                    log.debug("Extract task results to download PDF.")
                    task_result_url = progress_response.get("result")
                else:
…
```

However, pages can fail at any percentage, leading to repeated checks (which never complete):
```
INFO:atlassian.confluence:50% - FAILED
INFO:atlassian.confluence:Check if export task has completed.
INFO:atlassian.confluence:50% - FAILED
INFO:atlassian.confluence:Check if export task has completed.
…
```

This change makes the code check the Task-State at every poll-roundtrip and return an error whenever it is `ERROR`.
fixes #1202