### PR TITLE
Bitbucket Server: Add support to include required reviewers for PR

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -1588,6 +1588,37 @@ class Bitbucket(BitbucketBase):
             params["at"] = at
         return self._get_paged(url, params=params)
 
+    def get_required_reviewers_for_pull_request(
+        self, source_project, source_repo, dest_project, dest_repo, source_branch, dest_branch
+    ):
+        """
+        Get required reviewers for PR creation
+        :param source_project: the project that the PR source is from
+        :param source_repo: the repository that the PR source is from
+        :param source_branch: the branch name of the PR
+        :param dest_project: the project that the PR destination is from
+        :param dest_repo: the repository that the PR destination is from
+        :param dest_branch: where the PR is being merged into
+        :return:
+        """
+        url = "{}/reviewers".format(
+            self._url_repo(
+                dest_project,
+                dest_repo,
+                api_root="rest/default-reviewers",
+                api_version="1.0",
+            )
+        )
+        source_repo_id = self.get_repo(source_project, source_repo)["id"]
+        dest_repo_id = self.get_repo(dest_project, dest_repo)["id"]
+        params = {
+            "sourceRepoId": source_repo_id,
+            "sourceRefId": source_branch,
+            "targetRepoId": dest_repo_id,
+            "targetRefId": dest_branch,
+        }
+        return self.get(url, params=params)
+
     def open_pull_request(
         self,
         source_project,
@@ -1599,6 +1630,7 @@ class Bitbucket(BitbucketBase):
         title,
         description,
         reviewers=None,
+        include_required_reviewers=False,
     ):
         """
         Create a new pull request between two branches.
@@ -1614,6 +1646,7 @@ class Bitbucket(BitbucketBase):
         :param title: the title of the PR
         :param description: the description of what the PR does
         :param reviewers: the list of reviewers or a single reviewer of the PR
+        :param include_required_reviewers: OPTIONAL defaults to False, include required reviewers for the PR
         :return:
         """
         body = {
@@ -1641,6 +1674,13 @@ class Bitbucket(BitbucketBase):
         def add_reviewer(reviewer_name):
             entry = {"user": {"name": reviewer_name}}
             body["reviewers"].append(entry)
+
+        if not self.cloud and include_required_reviewers:
+            required_reviewers = self.get_required_reviewers_for_pull_request(
+                source_project, source_repo, dest_project, dest_repo, source_branch, destination_branch
+            )
+            for required_reviewer in required_reviewers:
+                add_reviewer(required_reviewer["name"])
 
         if reviewers is not None:
             if isinstance(reviewers, str):

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -211,6 +211,9 @@ Manage code
     # Reply to a comment of a pull request
     bitbucket.add_pull_request_comment(project, repository, pull_request_id, text, parent_id=None)
 
+    # Get required reviewers for PR creation
+    bitbucket.get_required_reviewers_for_pull_request(source_project, source_repo, dest_project, dest_repo, source_branch, dest_branch)
+
     # Create a new pull request between two branches.
     bitbucket.open_pull_request(source_project, source_repo, dest_project, dest_repo, source_branch, destination_branch, title, description)
 
@@ -219,6 +222,9 @@ Manage code
 
     # Create a new pull request between two branches with multiple reviewers.
     bitbucket.open_pull_request(source_project, source_repo, dest_project, dest_repo, source_branch, destination_branch, title, description, reviewers=['name1', 'name2'])
+
+    # Create a new pull request between two branches with required reviewers.
+    bitbucket.open_pull_request(source_project, source_repo, dest_project, dest_repo, source_branch, destination_branch, title, description, include_required_reviewers=True)
 
     # Delete a pull request
     bitbucket.delete_pull_request(project, repository, pull_request_id, pull_request_version)


### PR DESCRIPTION
Also add separate API to get required reviewers for a PR

See https://developer.atlassian.com/server/bitbucket/rest/v811/api-group-pull-requests/#api-default-reviewers-latest-projects-projectkey-repos-repositoryslug-reviewers-get