### PR TITLE
lists and dicts can be handled in raise_for_status

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -476,13 +476,13 @@ class AtlassianRestAPI(object):
                 if self.url == "https://api.atlassian.com":
                     error_msg = "\n".join([k + ": " + v for k, v in j.items()])
                 else:
-                    error_msg = "\n".join(
-                        j.get("errorMessages", list())
-                        + [
-                            k.get("message", "") if isinstance(k, dict) else v
-                            for k, v in j.get("errors", dict()).items()
-                        ]
-                    )
+                    error_msg_list = j.get("errorMessages", list())
+                    errors = j.get("errors", dict())
+                    if isinstance(errors, dict):
+                        error_msg_list.append(errors.get("message", ""))
+                    elif isinstance(errors, list):
+                        error_msg_list.extend([v.get("message", "") if isinstance(v, dict) else v for v in errors])
+                    error_msg = "\n".join(error_msg_list)
             except Exception as e:
                 log.error(e)
                 response.raise_for_status()

--- a/tests/mockup.py
+++ b/tests/mockup.py
@@ -39,6 +39,8 @@ def request_mockup(*args, **kwargs):
                     response.status_code = data.pop("status_code")
                 else:
                     response.status_code = 200
+                if "headers" in data:
+                    response.headers = data.pop("headers")
 
                 # Extend the links with the server
                 for item in [None, "owner", "project", "workspace"]:

--- a/tests/responses/jira/rest/api/2/issue/POST
+++ b/tests/responses/jira/rest/api/2/issue/POST
@@ -5,6 +5,12 @@ responses['{"fields": {"issuetype": "foo", "summary": "summary", "project": "pro
 }
 responses['{"fields": {"issuetype": "fail", "summary": "authentication", "project": "project"}}'] = {
     "status_code": 401,
-    "headers": {"Content-Type":	"application/json;charset=UTF-8"},
-    "errors": [{"context": None, "message": "Authentication failed. Please check your credentials and try again.", "exceptionName": "com.atlassian.bitbucket.auth.IncorrectPasswordAuthenticationException"}],
+    "headers": {"Content-Type": "application/json;charset=UTF-8"},
+    "errors": [
+        {
+            "context": None,
+            "message": "Authentication failed. Please check your credentials and try again.",
+            "exceptionName": "com.atlassian.bitbucket.auth.IncorrectPasswordAuthenticationException",
+        }
+    ],
 }

--- a/tests/responses/jira/rest/api/2/issue/POST
+++ b/tests/responses/jira/rest/api/2/issue/POST
@@ -3,3 +3,8 @@ responses['{"fields": {"issuetype": "foo", "summary": "summary", "project": "pro
     "errorMessages": [],
     "errors": {"labels": "Field 'labels' cannot be set. It is not on the appropriate screen, or unknown."},
 }
+responses['{"fields": {"issuetype": "fail", "summary": "authentication", "project": "project"}}'] = {
+    "status_code": 401,
+    "headers": {"Content-Type":	"application/json;charset=UTF-8"},
+    "errors": [{"context": None, "message": "Authentication failed. Please check your credentials and try again.", "exceptionName": "com.atlassian.bitbucket.auth.IncorrectPasswordAuthenticationException"}],
+}

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -49,3 +49,8 @@ class TestJira(TestCase):
         """Post an issue but receive a 400 error response"""
         with self.assertRaises(HTTPError):
             self.jira.create_issue(fields={"issuetype": "foo", "summary": "summary", "project": "project"})
+
+    def test_post_issue_expect_failed_authentication(self):
+        """Post an issue but receive a 401 error response"""
+        with self.assertRaises(HTTPError):
+            self.jira.create_issue(fields={"issuetype": "fail", "summary": "authentication", "project": "project"})


### PR DESCRIPTION
This should solve #1230.

I tried to straighten out the code a bit.

I am not sure why we checked if the key from .items() is a dict. That is not possible.

```python
tdk = {"hello": "world"}
td = {tdk: "cool it works"}
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: unhashable type: 'dict'
```

I guess in an earlier version we iterated over a presumed dict and named the variable k(for key) (But in the background it was a list). https://github.com/atlassian-api/atlassian-python-api/commit/fc620ae094c162f36d93ceaa0998ebbc1ca9bf20 

Then it was modified. But they then stopped iterating over the object but iterated over the items, which are apparently not always present. https://github.com/atlassian-api/atlassian-python-api/commit/4bb337a5d262912d6459d12d51aecf549e186eb5

I looks like some classic list/dict confusion but in the end I am not sure what possible responses are. Feedback would be appreciated. 

I shoehorned a testcases in there to check for this error.

With regards to https://github.com/atlassian-api/atlassian-python-api/pull/1228 . The response I got with that error has the content-type: 'application/json;charset=UTF-8' which he specifically does not trigger for.