### PR TITLE
Add `cert` Property Request

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -60,6 +60,7 @@ class AtlassianRestAPI(object):
         cloud=False,
         proxies=None,
         token=None,
+        cert=None,
     ):
         self.url = url
         self.username = username
@@ -72,6 +73,7 @@ class AtlassianRestAPI(object):
         self.advanced_mode = advanced_mode
         self.cloud = cloud
         self.proxies = proxies
+        self.cert = cert
         if session is None:
             self._session = requests.Session()
         else:
@@ -246,6 +248,7 @@ class AtlassianRestAPI(object):
             verify=self.verify_ssl,
             files=files,
             proxies=self.proxies,
+            cert=self.cert,
         )
         response.encoding = "utf-8"
 


### PR DESCRIPTION
**Background**
Some Jira instances have been configured behind reverse proxies that require a client certificate for authentication to even hit the server. The `requests` library that is used by the connection library allows a `cert` property for this client authentication.

**Change**
- Add the keyword argument property (`cert`) to the `AtlassianRestAPI` class that is passed to an instance variable and passed to the `session.request(...)` function

**References**
- https://docs.python-requests.org/en/latest/user/advanced/#client-side-certificates

