### PR TITLE
Documentation: Bitbucket project_grant_group_permissions parameter

### DIFF
--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -43,7 +43,7 @@ Manage projects
     bitbucket.project_grant_user_permissions(project_key, username, permission)
 
     # Grant project permission to a specific group
-    bitbucket.project_grant_group_permissions(project_key, groupname, permission)
+    bitbucket.project_grant_group_permissions(project_key, group_name, permission)
 
     # Remove default permission for project
     bitbucket.project_remove_default_permissions(project_key, permission)


### PR DESCRIPTION
The documentation lists "groupname" as the parameter accepted by project_grant_group_permissions, but group_name is expected:
https://github.com/atlassian-api/atlassian-python-api/blob/master/atlassian/bitbucket/__init__.py#L500