### PR TITLE
[ISSUE-1241] #1241, added propagation of `advanced_mode` flag 

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -343,6 +343,7 @@ class AtlassianRestAPI(object):
             params=params,
             trailing=trailing,
             absolute=absolute,
+            advanced_mode=advanced_mode,
         )
         if self.advanced_mode or advanced_mode:
             return response
@@ -379,6 +380,7 @@ class AtlassianRestAPI(object):
             params=params,
             trailing=trailing,
             absolute=absolute,
+            advanced_mode=advanced_mode,
         )
         if self.advanced_mode or advanced_mode:
             return response
@@ -420,6 +422,7 @@ class AtlassianRestAPI(object):
             params=params,
             trailing=trailing,
             absolute=absolute,
+            advanced_mode=advanced_mode,
         )
         if self.advanced_mode or advanced_mode:
             return response
@@ -457,6 +460,7 @@ class AtlassianRestAPI(object):
             params=params,
             trailing=trailing,
             absolute=absolute,
+            advanced_mode=advanced_mode,
         )
         if self.advanced_mode or advanced_mode:
             return response


### PR DESCRIPTION
#1241 

added propagation of the `advanced_mode` flag for `put`, `post`, `patch`, and `delete` functions.  Prior to this change, the `advanced_mode` flag was only propagated to the `request` method for `get` calls.  The `advanced_mode` `requests.Response` object is very useful in having code gracefully handle rate limit 429 responses from the server since the response headers will include the necessary backoff information that the client should use before making another request.