### PR TITLE
[ISSUE-1242]  prevented weird exceptions related to integer handling

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -477,7 +477,7 @@ class AtlassianRestAPI(object):
             try:
                 j = response.json()
                 if self.url == "https://api.atlassian.com":
-                    error_msg = "\n".join([k + ": " + v for k, v in j.items()])
+                    error_msg = "\n".join(["{}: {}".format(k, v) for k, v in j.items()])
                 else:
                     error_msg_list = j.get("errorMessages", list())
                     errors = j.get("errors", dict())


### PR DESCRIPTION
if keys or values in the response json are `int`s, the `k + ": " + v` expression will fail because an `int` is not a `str`.  In order to avoid this, we can either use `%`-formatting, `.format` formatting, or f-strings.  I chose f-strings for usability, but regardless of which direction, the issue should be addressed one of those ways.

addresses #1242 