### PR TITLE
Add Content-Type to calls to Assets in cloud

### DIFF
--- a/atlassian/insight.py
+++ b/atlassian/insight.py
@@ -43,7 +43,7 @@ class Insight(AtlassianRestAPI):
         # set cloud back to true and return
         kwargs["cloud"] = True
         # Insight cloud is particular about its headers.
-        self.default_headers = {"Accept": "application/json"}
+        self.default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         return args, kwargs
 
     def __get_workspace_id(self):


### PR DESCRIPTION
I experienced 415 error messages due to missing headers when making put and post calls to Assets in cloud.