### PR TITLE
Add account list to request participant methods

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -187,7 +187,7 @@ class ServiceDesk(AtlassianRestAPI):
             return response
         return (response or {}).get("values")
 
-    def add_request_participants(self, issue_id_or_key, users_list=[], account_list=[]):
+    def add_request_participants(self, issue_id_or_key, users_list=None, account_list=None):
         """
         Add users as participants to an existing customer request
         The calling user must have permission to manage participants for this customer request
@@ -197,11 +197,15 @@ class ServiceDesk(AtlassianRestAPI):
         :return:
         """
         url = "rest/servicedeskapi/request/{}/participant".format(issue_id_or_key)
-        data = {"usernames": users_list, "accountIds": account_list}
+        data = {}
+        if users_list is not None:
+            data["usernames"] = users_list
+        if account_list is not None:
+            data["accountIds"] = account_list
 
         return self.post(url, data=data, headers=self.experimental_headers)
 
-    def remove_request_participants(self, issue_id_or_key, users_list=[], account_list=[]):
+    def remove_request_participants(self, issue_id_or_key, users_list=None, account_list=None):
         """
         Remove participants from an existing customer request
         The calling user must have permission to manage participants for this customer request
@@ -211,7 +215,11 @@ class ServiceDesk(AtlassianRestAPI):
         :return:
         """
         url = "rest/servicedeskapi/request/{}/participant".format(issue_id_or_key)
-        data = {"usernames": users_list, "accountIds": account_list}
+        data = {}
+        if users_list is not None:
+            data["usernames"] = users_list
+        if account_list is not None:
+            data["accountIds"] = account_list
 
         return self.delete(url, data=data, headers=self.experimental_headers)
 

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -187,7 +187,7 @@ class ServiceDesk(AtlassianRestAPI):
             return response
         return (response or {}).get("values")
 
-    def add_request_participants(self, issue_id_or_key, users_list):
+    def add_request_participants(self, issue_id_or_key, users_list=[], account_list=[]):
         """
         Add users as participants to an existing customer request
         The calling user must have permission to manage participants for this customer request
@@ -197,11 +197,11 @@ class ServiceDesk(AtlassianRestAPI):
         :return:
         """
         url = "rest/servicedeskapi/request/{}/participant".format(issue_id_or_key)
-        data = {"usernames": users_list}
+        data = {"usernames": users_list, "accountIds": account_list}
 
         return self.post(url, data=data, headers=self.experimental_headers)
 
-    def remove_request_participants(self, issue_id_or_key, users_list):
+    def remove_request_participants(self, issue_id_or_key, users_list=[], account_list=[]):
         """
         Remove participants from an existing customer request
         The calling user must have permission to manage participants for this customer request
@@ -211,7 +211,7 @@ class ServiceDesk(AtlassianRestAPI):
         :return:
         """
         url = "rest/servicedeskapi/request/{}/participant".format(issue_id_or_key)
-        data = {"usernames": users_list}
+        data = {"usernames": users_list, "accountIds": account_list}
 
         return self.delete(url, data=data, headers=self.experimental_headers)
 

--- a/docs/service_desk.rst
+++ b/docs/service_desk.rst
@@ -60,11 +60,11 @@ Manage a Participants
 
     # Add request participants
     # The calling user must have permission to manage participants for this customer request
-    sd.add_request_participants(issue_id_or_key, users_list)
+    sd.add_request_participants(issue_id_or_key, users_list=[], account_list=[])
 
     # Remove request participants
     # The calling user must have permission to manage participants for this customer request
-    sd.remove_request_participants(issue_id_or_key, users_list)
+    sd.remove_request_participants(issue_id_or_key, users_list=[], account_list=[])
 
 Transitions
 -----------

--- a/docs/service_desk.rst
+++ b/docs/service_desk.rst
@@ -60,11 +60,11 @@ Manage a Participants
 
     # Add request participants
     # The calling user must have permission to manage participants for this customer request
-    sd.add_request_participants(issue_id_or_key, users_list=[], account_list=[])
+    sd.add_request_participants(issue_id_or_key, users_list=None, account_list=None)
 
     # Remove request participants
     # The calling user must have permission to manage participants for this customer request
-    sd.remove_request_participants(issue_id_or_key, users_list=[], account_list=[])
+    sd.remove_request_participants(issue_id_or_key, users_list=None, account_list=None)
 
 Transitions
 -----------


### PR DESCRIPTION
Due to deprication of usernames in Jira Cloud the option to use accountid when updating requestparticipant is required.
https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/