### PR TITLE
Fix Python 3.12 build

### DIFF
--- a/Dockerfile.qa
+++ b/Dockerfile.qa
@@ -57,6 +57,7 @@ RUN apt-get clean
 WORKDIR /atlassian-python-api
 COPY requirements.txt .
 COPY requirements-dev.txt .
+RUN python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade wheel
 RUN python3 -m pip install --no-cache-dir -r requirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,7 @@ basepython = python3
 exclude =  __pycache__
 skip_install = true
 deps =
-    importlib-metadata<=4.13.0
     flake8
-    flake8-no-fstring
 commands = flake8 {[base]linting_targets}
 
 [testenv:pylint]


### PR DESCRIPTION
Fixes the Python 3.12 CI build (see #1262).

#### Remarks:

The flake8 version used in the CI build is quite old, but an upgrade is blocked by `flake8-no-fstring` (needs flake8<4). An update to the latest version isn't possible as flake8 6.x does no longer support Python 3.6 and 3.7.

Are `importlib-metadata` downgrade and `flake8-no-fstring` still necessary? The later should be fixed by recent flake8 versions.