### PR TITLE
[Jira]: Migrate get all projects methods to use paginated endpoint for Jira Cloud.

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2173,7 +2173,8 @@ class Jira(AtlassianRestAPI):
         if expand:
             params["expand"] = expand
         page_url = url or self.resource_url("project/search")
-        return self.get(page_url, params=params)
+        is_url_absolute = bool(page_url.lower().startswith("http"))
+        return self.get(page_url, params=params, absolute=is_url_absolute)
 
     def projects_from_server(self, included_archived=None, expand=None):
         """

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2110,12 +2110,82 @@ class Jira(AtlassianRestAPI):
         return self.projects(included_archived, expand)
 
     def projects(self, included_archived=None, expand=None):
-        """Returns all projects which are visible for the currently logged-in user.
+        """
+        Returns all projects which are visible for the currently logged-in user.
         If no user is logged in, it returns the list of projects that are visible when using anonymous access.
         :param included_archived: boolean whether to include archived projects in response, default: false
         :param expand:
         :return:
         """
+        if self.cloud:
+            return self.projects_from_cloud(
+                included_archived=included_archived,
+                expand=expand,
+            )
+        else:
+            return self.projects_from_server(
+                included_archived=included_archived,
+                expand=expand,
+            )
+
+    def projects_from_cloud(self, included_archived=None, expand=None):
+        """
+        Returns all projects which are visible for the currently logged-in user.
+        Cloud version should use the ``paginated``endpoint to get pages of projects, as the old endpoint is deprecated.
+        If no user is logged in, it returns the list of projects that are visible when using anonymous access.
+        :param included_archived: boolean whether to include archived projects in response, default: false
+        :param expand:
+        :return:
+        """
+        if not self.cloud:
+            raise ValueError("``projects_from_cloud`` method is only available for Jira Cloud platform")
+
+        projects = self.paginated_projects(
+            included_archived=included_archived,
+            expand=expand,
+        )
+        while not projects.get("isLast"):
+            projects["values"].extend(
+                self.paginated_projects(
+                    included_archived=included_archived,
+                    expand=expand,
+                    url=projects["nextPage"],
+                )["values"]
+            )
+        return projects["values"]
+
+    def paginated_projects(self, included_archived=None, expand=None, url=None):
+        """
+        Returns a page of projects which are visible for the currently logged-in user.
+        Method to be used only for Jira Cloud platform, until tests on Jira Server are executed.
+        If no user is logged in, it returns the list of projects that are visible when using anonymous access.
+        :param included_archived: boolean whether to include archived projects in response, default: false
+        :param expand:
+        :param url: url to get the next page of projects, default: false (first page)
+        :return:
+        """
+        if not self.cloud:
+            raise ValueError("``projects_from_cloud`` method is only available for Jira Cloud platform")
+
+        params = {}
+        if included_archived:
+            params["includeArchived"] = included_archived
+        if expand:
+            params["expand"] = expand
+        page_url = url or self.resource_url("project/search")
+        return self.get(page_url, params=params)
+
+    def projects_from_server(self, included_archived=None, expand=None):
+        """
+        Returns all projects which are visible for the currently logged-in user.
+        If no user is logged in, it returns the list of projects that are visible when using anonymous access.
+        :param included_archived: boolean whether to include archived projects in response, default: false
+        :param expand:
+        :return:
+        """
+        if self.cloud:
+            raise ValueError("``projects_from_server`` method is only available for Jira Server platform")
+
         params = {}
         if included_archived:
             params["includeArchived"] = included_archived
@@ -2180,7 +2250,7 @@ class Jira(AtlassianRestAPI):
         """
         base_url = self.resource_url("project")
         url = "{base_url}/{key}/archive".format(base_url=base_url, key=key)
-        return self.put(url)
+        return self.post(url)
 
     def project(self, key, expand=None):
         """

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -112,11 +112,26 @@ Manage projects
 
     # Get all projects
     # Returns all projects which are visible for the currently logged in user.
-    jira.projects(included_archived=None)
+    jira.projects(included_archived=None, expand=None)
 
     # Get all project alternative call
     # Returns all projects which are visible for the currently logged in user.
-    jira.get_all_projects(included_archived=None)
+    jira.get_all_projects(included_archived=None, expand=None)
+
+    # Get all projects only for Jira Cloud
+    # Returns all projects which are visible for the currently logged in user.
+    jira.projects_from_cloud(included_archived=None, expand=None)
+
+    # Get one page of projects
+    # Returns a paginated list of projects visible for the currently logged in user.
+    # Use the url formatting to get a specific page as shown here:
+    # url = f"{self.resource_url("project/search")}?startAt={start_at}&maxResults={max_results}"
+    # Defaults to the first page, which returns a nextPage url when available.
+    jira.projects_paginated(included_archived=None, expand=None, url=None)
+
+    # Get all projects only for Jira Server
+    # Returns all projects which are visible for the currently logged in user.
+    jira.projects_from_server(included_archived=None, expand=None)
 
     # Delete project
     jira.delete_project(key)


### PR DESCRIPTION
* Migrate "get all projects" methods to use paginated endpoint for Jira Cloud.
* Update docs.
* Use the correct method in the archive project method.