### PR TITLE
Updating user_get_websudo to set the not_json_response as true #1267

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1966,11 +1966,12 @@ class Jira(AtlassianRestAPI):
             "webSudoPassword": self.password,
             "webSudoIsPost": "false",
         }
-        answer = self.get("secure/admin/WebSudoAuthenticate.jspa", self.form_token_headers)
+        answer = self.get("secure/admin/WebSudoAuthenticate.jspa", self.form_token_headers, not_json_response=True)
+        decoded_answer = answer.decode()
         atl_token = None
-        if answer:
+        if decoded_answer:
             atl_token = (
-                answer.split('<meta id="atlassian-token" name="atlassian-token" content="')[1]
+                decoded_answer.split('<meta id="atlassian-token" name="atlassian-token" content="')[1]
                 .split("\n")[0]
                 .split('"')[0]
             )


### PR DESCRIPTION
Currently, the user_get_websudo method is throwing an 'Expecting value: line 10 column 1 (char 9)' exception because of the lack of not_json_response parameter not being passed in the user_get_websudo method. Pushing this PR to fix this issue