### PR TITLE
JIRA: Add `notify_users` option to 2 methods

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1161,6 +1161,15 @@ class Jira(AtlassianRestAPI):
         return issue["fields"]
 
     def update_issue_field(self, key, fields="*all", notify_users=True):
+        """
+        Update an issue's fields.
+        :param key: str Issue id or issye key
+        :param fields: dict with target fields as keys and new contents as values
+        :param notify_users: bool OPTIONAL if True, use project's default notification scheme to notify users via email.
+                                           if False, do not send any email notifications. (only works with admin privilege)
+
+        Reference: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-put
+        """
         base_url = self.resource_url("issue")
         params = {"notifyUsers": "true" if notify_users else "false"}
         return self.put(

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1160,11 +1160,13 @@ class Jira(AtlassianRestAPI):
         issue = self.get("{base_url}/{key}".format(base_url=base_url, key=key))
         return issue["fields"]
 
-    def update_issue_field(self, key, fields="*all"):
+    def update_issue_field(self, key, fields="*all", notify_users=True):
         base_url = self.resource_url("issue")
+        params = {"notifyUsers": "true" if notify_users else "false"}
         return self.put(
             "{base_url}/{key}".format(base_url=base_url, key=key),
             data={"fields": fields},
+            params=params,
         )
 
     def bulk_update_issue_field(self, key_list, fields="*all"):
@@ -1465,13 +1467,14 @@ class Jira(AtlassianRestAPI):
             data["visibility"] = visibility
         return self.post(url, data=data)
 
-    def issue_edit_comment(self, issue_key, comment_id, comment, visibility=None):
+    def issue_edit_comment(self, issue_key, comment_id, comment, visibility=None, notify_users=True):
         """
         Updates an existing comment
         :param issue_key: str
         :param comment_id: int
         :param comment: str
         :param visibility: OPTIONAL
+        :param notify_users: bool OPTIONAL
         :return:
         """
         base_url = self.resource_url("issue")
@@ -1481,7 +1484,8 @@ class Jira(AtlassianRestAPI):
         data = {"body": comment}
         if visibility:
             data["visibility"] = visibility
-        return self.put(url, data=data)
+        params = {"notifyUsers": "true" if notify_users else "false"}
+        return self.put(url, data=data, params=params)
 
     def get_issue_remotelinks(self, issue_key, global_id=None, internal_id=None):
         """

--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -219,7 +219,7 @@ Manage issues
 
     # Update issue field
     fields = {'summary': 'New summary'}
-    jira.update_issue_field(key, fields)
+    jira.update_issue_field(key, fields, notify_users=True)
 
     # Get existing custom fields or find by filter
     jira.get_custom_fields(self, search=None, start=1, limit=50):
@@ -315,6 +315,9 @@ Manage issues
 
     # Add Comments
     jira.issue_add_comment(issue_id_or_key, "This is a sample comment string.")
+
+    # Edit Comments
+    jira.issue_edit_comment(issue_key, comment_id, comment, visibility=None, notify_users=True)
 
     # Issue Comments
     jira.issue_get_comments(issue_id_or_key)


### PR DESCRIPTION
`update_issue_field` method can utilize `"notifyUsers"` query parameter to enable/disable email notification. 
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-put

So does `issue_edit_coment` method as well.
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-put