### PR TITLE
[Confluence] added new method get tables from confluence page.

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -4,6 +4,7 @@ import os
 import time
 import json
 from bs4  import BeautifulSoup
+import lxml
 from requests import HTTPError
 import requests
 from deprecated import deprecated

--- a/docs/confluence.rst
+++ b/docs/confluence.rst
@@ -152,6 +152,8 @@ Page actions
     # Add comment into page
     confluence.add_comment(page_id, text)
 
+    # Fetch tables from Confluence page
+    confluence.get_page_tables(page_id)
 Template actions
 ----------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ six
 oauthlib
 requests_oauthlib
 requests-kerberos==0.14.0
+lxml
+beautifulsoup4


### PR DESCRIPTION
Added new method get_page_tables to confluence.py. 
* This function scraps all the html tables added to confluence page and returns them as list of nested lists (each nested list corresponds to table row). 
* Two extra dependencies were added to requirements.txt:
* BeautifulSoup4  and lxml  
