### PR TITLE
Fix download_attachments_from_page documentation

### DIFF
--- a/docs/confluence.rst
+++ b/docs/confluence.rst
@@ -120,8 +120,8 @@ Page actions
     # automatically version the new file and keep the old one
     confluence.attach_content(content, name=None, content_type=None, page_id=None, title=None, space=None, comment=None)
 
-    # Download attachments from a page to local system.
-    confluence.download_attachments(page_id, download_path, path=None)
+    # Download attachments from a page to local system. If download_path is None, current working directory will be used.
+    confluence.download_attachments_from_page(page_id, download_path=None)
 
     # Remove completely a file if version is None or delete version
     confluence.delete_attachment(page_id, filename, version=None)


### PR DESCRIPTION
The docs mention a function with the name `download_attachments`, but this function does not exist. This doc entry was added in #1283 which also adds the function `download_attachments_from_page`. I assume it's a simple mistake in the docs, so here a PR to update the docs.