### PR TITLE
add remove_space_permission

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -3008,6 +3008,24 @@ class Confluence(AtlassianRestAPI):
 
         return self.post(url, data=data, headers=self.experimental_headers)
 
+    def remove_space_permission(self, space_key, user, permission):
+        """
+        The JSON-RPC APIs for Confluence are provided here to help you browse and discover APIs you have access to.
+        JSON-RPC APIs operate differently than REST APIs.
+        To learn more about how to use these APIs,
+        please refer to the Confluence JSON-RPC documentation on Atlassian Developers.
+        """
+        if self.api_version == "cloud":
+            return {}
+        url = "rpc/json-rpc/confluenceservice-v2"
+        data = {
+            "jsonrpc": "2.0",
+            "method": "removePermissionFromSpace",
+            "id": 9,
+            "params": [permission, user, space_key],
+        }
+        return self.post(url, data=data).get("result") or {}
+
     def get_space_permissions(self, space_key):
         """
         The JSON-RPC APIs for Confluence are provided here to help you browse and discover APIs you have access to.


### PR DESCRIPTION
Add possibility to remove a space permission. Uses the JSON RPC interface.

Not implemented for cloud.