### PR TITLE
Use correct name for Beautiful Soup in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ oauthlib
 requests_oauthlib
 requests-kerberos==0.14.0
 jmespath
-bs4
+beautifulsoup4
 lxml

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-cov
     coverage
     requests
-    bs4
+    beautifulsoup4
 commands =
     coverage erase
     pytest -v --cov=atlassian --cov-branch --cov-report=xml


### PR DESCRIPTION
As noted at https://pypi.org/project/bs4/, the official name of the Beautiful Soup package is beautifulsoup4, while bs4 is just an alias. In distribution packaging (such as Fedora) the package may not be available under this alias, so it's better to use the official name.