### PR TITLE
Use requirements file for install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,18 @@ with open(os.path.join("atlassian", "VERSION")) as file:
 with open("README.rst") as file:
     long_description = file.read()
 
+
+def get_install_requires():
+    """Lets read requirements.txt and properly set dependencies.
+    We keep only one source of required packages, no need to change this file here.
+
+    Another advantage: build will fail if requirements file contains wrong libraries"""
+
+    with open('requirements.txt', 'r') as f:
+        lines = [a.strip('\n').strip() for a in f.readlines() if not a.startswith('#')]
+    return [a for a in lines if a]
+
+
 setup(
     name="atlassian-python-api",
     description="Python Atlassian REST API Wrapper",
@@ -25,7 +37,7 @@ setup(
     package_dir={"atlassian": "atlassian"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["deprecated", "requests", "six", "oauthlib", "requests_oauthlib", "jmespath"],
+    install_requires=get_install_requires(),
     extras_require={"kerberos": ["requests-kerberos"]},
     platforms="Platform Independent",
     classifiers=[


### PR DESCRIPTION
Let's define `install_requires` inside `setup.py` out of `requirements.txt` file.
We keep then only one source of dependencies and we let build fail early (on wheel build) if `requirements.txt` contains wrong dependencies.