### PR TITLE
#1295 BUGFIX - bs4 vs beautifulsoup4

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -7,7 +7,7 @@ import json
 from requests import HTTPError
 import requests
 from deprecated import deprecated
-from beautifulsoup4 import BeautifulSoup
+from bs4 import BeautifulSoup
 from atlassian import utils
 from .errors import ApiError, ApiNotFoundError, ApiPermissionError, ApiValueError, ApiConflictError, ApiNotAcceptable
 from .rest_client import AtlassianRestAPI

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,18 @@ with open(os.path.join("atlassian", "VERSION")) as file:
 with open("README.rst") as file:
     long_description = file.read()
 
+
+def get_install_requires():
+    """Lets read requirements.txt and properly set dependencies.
+    We keep only one source of required packages, no need to change this file here.
+
+    Another advantage: build will fail if requirements file contains wrong libraries"""
+
+    with open('requirements.txt', 'r') as f:
+        lines = [a.strip('\n').strip() for a in f.readlines() if not a.startswith('#')]
+    return [a for a in lines if a]
+
+
 setup(
     name="atlassian-python-api",
     description="Python Atlassian REST API Wrapper",
@@ -25,7 +37,7 @@ setup(
     package_dir={"atlassian": "atlassian"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["deprecated", "requests", "six", "oauthlib", "requests_oauthlib", "jmespath"],
+    install_requires=get_install_requires(),
     extras_require={"kerberos": ["requests-kerberos"]},
     platforms="Platform Independent",
     classifiers=[


### PR DESCRIPTION
beautifulsoup4 is a package name, while import must be from bs4 - according to BS docs
Correct:
`from bs4 import BeautifulSoup`
Wrong:
`from beautifulsoup4 import BeautifulSoup`

Dependency on package `beautifulsoup4` - as in `requirements.txt` file (not used up to now for wheel build)