### PR TITLE
[jira] new feature added scrap_regex_from_issue + docs + example

### DIFF
--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -363,6 +363,8 @@ Manage issues
     # started is a date string in the format %Y-%m-%dT%H:%M:%S.000+0000%z
     jira.issue_worklog(issue_key, started, time_in_sec)
 
+    # Scrap regex matches from issue description and comments:
+    jira.scrap_regex_from_issue(issue_key, regex)
 
 
 Epic Issues

--- a/examples/jira/jira_get_comment.py
+++ b/examples/jira/jira_get_comment.py
@@ -1,5 +1,6 @@
 """ Example: Get Comments on a Jira Issue
 """
+
 # coding=utf-8
 from atlassian import Jira
 

--- a/examples/jira/jira_oauth2.py
+++ b/examples/jira/jira_oauth2.py
@@ -5,6 +5,7 @@
     token and Using access token, Jira cloud ID is identified and
     the available projects are returned.
 """
+
 from requests_oauthlib import OAuth2Session
 from atlassian.jira import Jira
 from flask import Flask, request, redirect, session

--- a/examples/jira/jira_scrap_regex_from_issue.py
+++ b/examples/jira/jira_scrap_regex_from_issue.py
@@ -1,0 +1,9 @@
+from atlassian import Jira
+
+## This feature can be useful if you need to scrap some data from issue description or comments.
+jira = Jira(url="http://localhost:8080", username="admin", password="admin")
+regex = r"((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\[?\.\]?){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"  # regex for ipv4 address + ipv4 with [.] instead of dot
+issue = "TEST-1"  # id of the jira issue
+result = jira.scrap_regex_from_issue(
+    issue, regex
+)  ## scrap_regex_from_issue will return results of positive regexes matches from issue description and issue comments.

--- a/examples/jira/jira_scrap_regex_from_issue.py
+++ b/examples/jira/jira_scrap_regex_from_issue.py
@@ -1,9 +1,8 @@
 from atlassian import Jira
 
-## This feature can be useful if you need to scrap some data from issue description or comments.
+# This feature can be useful if you need to scrap some data from issue description or comments.
 jira = Jira(url="http://localhost:8080", username="admin", password="admin")
 regex = r"((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\[?\.\]?){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"  # regex for ipv4 address + ipv4 with [.] instead of dot
 issue = "TEST-1"  # id of the jira issue
-result = jira.scrap_regex_from_issue(
-    issue, regex
-)  ## scrap_regex_from_issue will return results of positive regexes matches from issue description and issue comments.
+result = jira.scrap_regex_from_issue(issue, regex)
+# scrap_regex_from_issue will return results of positive regexes matches from issue description and issue comments.


### PR DESCRIPTION
* Added new method to jira api scrap_regex_from_issue.
*  This method takes issue_id as an input + specified regex and returns all regex matches found in issue comments and descriptions.
* Commits also includes docs + examples.
* have tried to cover this feature with unit test but I didn't manage to make use of mockup files when using method patching:


` 
try:
from unittest.mock import patch, MagicMock
except ImportError:
from mock import patch
def test_scrap_regex_from_issue(self):
regex = r"((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[?.]?){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
mock_without_comments = "< saved output from api1>"
mock_with_comments = "< saved output from api2>"
  with patch("atlassian.Jira.get_issue") as mock_get_tables:
  mock_get_tables.return_value = mock_without_comments
  result = self.jira.scrap_regex_from_issue("REGEX-123", regex)
  self.assertEqual(result, ["1.1.1.1", "11.1.1.3", "255.255.255.255"])
  mock_get_tables.return_value = mock_with_comments
  result = self.jira.scrap_regex_from_issue("REGEX-123", regex)
  self.assertEqual(result, ["1.1.1.1", "11.1.1.3", "255.255.255.255", "222.41.32.111", "77.123.123.123"])

`

above code works fine with the unit tests (when mockup output assigned to the variable in the file), but when I added my mockup files to responses folder (next to "FOO-123" issue) I wasn't able to use mock within patch function.
To sum up, my PR doesn't include unit tests at this point,  unless you are ok with including the mocked  output directly  into the test case scenario. 