### PR TITLE
[Bitbucket] Split pull request activities url for Cloud and Server

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -1781,7 +1781,10 @@ class Bitbucket(BitbucketBase):
         :param start:
         :return:
         """
-        url = "{}/activity".format(self._url_pull_request(project_key, repository_slug, pull_request_id))
+        if self.cloud:
+            url = "{}/activity".format(self._url_pull_request(project_key, repository_slug, pull_request_id))
+        else:
+            url = "{}/activities".format(self._url_pull_request(project_key, repository_slug, pull_request_id))
         params = {}
         if start:
             params["start"] = start


### PR DESCRIPTION
The latest release of the atlassian-python-api package modified the pull_request_activities url to use the `activity` endpoint which matches the [Bitbucket Cloud API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-activity-get). However, the latest [Bitbucket Server API](https://developer.atlassian.com/server/bitbucket/rest/v818/api-group-pull-requests/#api-api-latest-projects-projectkey-repos-repositoryslug-pull-requests-pullrequestid-activities-get) still uses the activities endpoint. These changes fix the method to switch between the two endpoints as appropriate using the `cloud` attribute.