### PR TITLE
Issue 1337: Bearer token on linux environment has new line character

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -101,7 +101,7 @@ class AtlassianRestAPI(object):
         self._session.auth = (username, password)
 
     def _create_token_session(self, token):
-        self._update_header("Authorization", "Bearer {token}".format(token=token))
+        self._update_header("Authorization", "Bearer {token}".format(token=token.strip()))
 
     def _create_kerberos_session(self, _):
         from requests_kerberos import OPTIONAL, HTTPKerberosAuth


### PR DESCRIPTION
#1337 New line character issue on linux environment

Below are the test results [ALL PASSED]
```bash
 > make qa
tox
py3: install_deps> python -I -m pip install beautifulsoup4 coverage pytest pytest-cov requests
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
.pkg: _optional_hooks> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: install_requires_for_build_wheel> python -I -m pip install wheel
.pkg: prepare_metadata_for_build_wheel> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py3: install_package_deps> python -I -m pip install beautifulsoup4 deprecated jmespath oauthlib requests requests-kerberos requests-oauthlib six
py3: install_package> python -I -m pip install --force-reinstall --no-deps /Users/ashishpatel/workspace/atlassian-python-api/.tox/.tmp/package/1/atlassian-python-api-3.41.10.tar.gz
py3: commands[0]> coverage erase
py3: commands[1]> pytest -v --cov=atlassian --cov-branch --cov-report=xml
================================================================= test session starts =================================================================
platform darwin -- Python 3.11.4, pytest-8.0.1, pluggy-1.4.0 -- /Users/ashishpatel/workspace/atlassian-python-api/.tox/py3/bin/python
cachedir: .tox/py3/.pytest_cache
rootdir: /Users/ashishpatel/workspace/atlassian-python-api
plugins: cov-4.1.0
collected 117 items                                                                                                                                   

tests/test_base.py::TestBasic::test_init_jira PASSED                                                                                            [  0%]
tests/test_base.py::TestBasic::test_init_confluence PASSED                                                                                      [  1%]
tests/test_base.py::TestBasic::test_init_bitbucket PASSED                                                                                       [  2%]
tests/test_base.py::TestBasic::test_init_bamboo PASSED                                                                                          [  3%]
tests/test_base.py::TestBasic::test_init_crowd PASSED                                                                                           [  4%]
tests/test_base.py::TestBasic::test_init_service_desk PASSED                                                                                    [  5%]
tests/test_base.py::TestBasic::test_init_xray PASSED                                                                                            [  5%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_exists_workspace PASSED                                                                       [  6%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_not_exists_workspace PASSED                                                                   [  7%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_not_exists_project PASSED                                                                     [  8%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_exists_repository PASSED                                                                      [  9%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_not_exists_repository PASSED                                                                  [ 10%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_create_repositories PASSED                                                                    [ 11%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_repositories PASSED                                                                       [ 11%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipelines PASSED                                                                          [ 12%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_trigger_pipeline PASSED                                                                       [ 13%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline PASSED                                                                           [ 14%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_stop_pipeline PASSED                                                                          [ 15%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_steps PASSED                                                                     [ 16%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step PASSED                                                                      [ 17%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step_log_1 PASSED                                                                [ 17%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step_log_2 PASSED                                                                [ 18%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_issues PASSED                                                                             [ 19%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_create_issue PASSED                                                                           [ 20%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_issue PASSED                                                                              [ 21%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_update_issue PASSED                                                                           [ 22%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_issue PASSED                                                                           [ 23%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_branch_restrictions PASSED                                                                [ 23%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_update_branch_restriction PASSED                                                              [ 24%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_branch_restriction PASSED                                                              [ 25%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_default_reviewers PASSED                                                                  [ 26%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_is_default_reviewer PASSED                                                                    [ 27%]
tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_default_reviewer PASSED                                                                [ 28%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_id PASSED                                                                              [ 29%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_title PASSED                                                                           [ 29%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_description PASSED                                                                     [ 30%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_is_declined PASSED                                                                     [ 31%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_is_merged PASSED                                                                       [ 32%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_is_open PASSED                                                                         [ 33%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_is_superseded PASSED                                                                   [ 34%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_created_on PASSED                                                                      [ 35%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_updated_on PASSED                                                                      [ 35%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_close_source_branch PASSED                                                             [ 36%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_source_branch PASSED                                                                   [ 37%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_destination_branch PASSED                                                              [ 38%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_comment_count PASSED                                                                   [ 39%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_task_count PASSED                                                                      [ 40%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_declined_reason PASSED                                                                 [ 41%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_author PASSED                                                                          [ 41%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_participants PASSED                                                                    [ 42%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_reviewers PASSED                                                                       [ 43%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_commits PASSED                                                                         [ 44%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_comment PASSED                                                                         [ 45%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_comments PASSED                                                                        [ 46%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_add_task PASSED                                                                        [ 47%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_update_task PASSED                                                                     [ 47%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_delete_task PASSED                                                                     [ 48%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_tasks PASSED                                                                           [ 49%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_approve PASSED                                                                         [ 50%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_unapprove PASSED                                                                       [ 51%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_request_changes PASSED                                                                 [ 52%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_unrequest_changes PASSED                                                               [ 52%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_decline PASSED                                                                         [ 53%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_merge PASSED                                                                           [ 54%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_each PASSED                                                                            [ 55%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_create PASSED                                                                          [ 56%]
tests/test_bitbucket_cloud_oo.py::TestPullRequests::test_builds PASSED                                                                          [ 57%]
tests/test_bitbucket_server.py::TestWebhook::test_create_webhook PASSED                                                                         [ 58%]
tests/test_bitbucket_server.py::TestWebhook::test_delete_webhook PASSED                                                                         [ 58%]
tests/test_bitbucket_server.py::TestWebhook::test_get_webhook PASSED                                                                            [ 59%]
tests/test_bitbucket_server.py::TestWebhook::test_get_webhooks PASSED                                                                           [ 60%]
tests/test_bitbucket_server.py::TestWebhook::test_update_webhook PASSED                                                                         [ 61%]
tests/test_bitbucket_server_oo.py::TestBasic::test_global_permissions PASSED                                                                    [ 62%]
tests/test_bitbucket_server_oo.py::TestBasic::test_projects PASSED                                                                              [ 63%]
tests/test_bitbucket_server_oo.py::TestBasic::test_project_permissions PASSED                                                                   [ 64%]
tests/test_bitbucket_server_oo.py::TestBasic::test_repositories PASSED                                                                          [ 64%]
tests/test_bitbucket_server_oo.py::TestBasic::test_repository_permissions PASSED                                                                [ 65%]
tests/test_bitbucket_server_oo.py::TestBasic::test_download_repo_archive PASSED                                                                 [ 66%]
tests/test_confluence_advanced_mode.py::TestConfluenceAdvancedModeCalls::test_confluence_advanced_mode_delete SKIPPED (credentials.secret m...) [ 67%]
tests/test_confluence_advanced_mode.py::TestConfluenceAdvancedModeCalls::test_confluence_advanced_mode_post SKIPPED (credentials.secret mis...) [ 68%]
tests/test_confluence_advanced_mode.py::TestConfluenceAdvancedModeCalls::test_confluence_advanced_mode_put SKIPPED (credentials.secret miss...) [ 69%]
tests/test_confluence_attach.py::TestConfluenceAttach::test_confluence_attach_content SKIPPED (credentials.secret missing, skipping test)       [ 70%]
tests/test_confluence_attach.py::TestConfluenceAttach::test_confluence_attach_file_1 SKIPPED (credentials.secret missing, skipping test)        [ 70%]
tests/test_confluence_attach.py::TestConfluenceAttach::test_confluence_attach_file_2 SKIPPED (credentials.secret missing, skipping test)        [ 71%]
tests/test_jira.py::TestJira::test_delete_issue_property PASSED                                                                                 [ 72%]
tests/test_jira.py::TestJira::test_delete_issue_property_not_found PASSED                                                                       [ 73%]
tests/test_jira.py::TestJira::test_get_epic_issues PASSED                                                                                       [ 74%]
tests/test_jira.py::TestJira::test_get_epic_issues_not_found PASSED                                                                             [ 75%]
tests/test_jira.py::TestJira::test_get_issue PASSED                                                                                             [ 76%]
tests/test_jira.py::TestJira::test_get_issue_comment PASSED                                                                                     [ 76%]
tests/test_jira.py::TestJira::test_get_issue_comment_not_found PASSED                                                                           [ 77%]
tests/test_jira.py::TestJira::test_get_issue_comments PASSED                                                                                    [ 78%]
tests/test_jira.py::TestJira::test_get_issue_not_found PASSED                                                                                   [ 79%]
tests/test_jira.py::TestJira::test_get_issue_property PASSED                                                                                    [ 80%]
tests/test_jira.py::TestJira::test_get_issue_property_keys PASSED                                                                               [ 81%]
tests/test_jira.py::TestJira::test_get_issue_property_keys_not_found PASSED                                                                     [ 82%]
tests/test_jira.py::TestJira::test_get_issue_property_not_found PASSED                                                                          [ 82%]
tests/test_jira.py::TestJira::test_post_issue_expect_failed_authentication PASSED                                                               [ 83%]
tests/test_jira.py::TestJira::test_post_issue_with_invalid_request PASSED                                                                       [ 84%]
tests/test_jira.py::TestJira::test_set_issue_property_create PASSED                                                                             [ 85%]
tests/test_jira.py::TestJira::test_set_issue_property_update PASSED                                                                             [ 86%]
tests/test_servicedesk.py::TestBasic::test_create_customer PASSED                                                                               [ 87%]
tests/test_servicedesk.py::TestBasic::test_get_organisations PASSED                                                                             [ 88%]
tests/test_servicedesk.py::TestBasic::test_get_organizations PASSED                                                                             [ 88%]
tests/test_servicedesk.py::TestBasic::test_get_organisations_servicedesk_id PASSED                                                              [ 89%]
tests/test_servicedesk.py::TestBasic::test_get_organizations_servicedesk_id PASSED                                                              [ 90%]
tests/test_servicedesk.py::TestBasic::test_get_organization PASSED                                                                              [ 91%]
tests/test_servicedesk.py::TestBasic::test_get_users_in_organization PASSED                                                                     [ 92%]
tests/test_servicedesk.py::TestBasic::test_create_organization PASSED                                                                           [ 93%]
tests/test_servicedesk.py::TestBasic::test_add_organization PASSED                                                                              [ 94%]
tests/test_servicedesk.py::TestBasic::test_remove_organization PASSED                                                                           [ 94%]
tests/test_servicedesk.py::TestBasic::test_delete_organization PASSED                                                                           [ 95%]
tests/test_servicedesk.py::TestBasic::test_add_users_to_organization PASSED                                                                     [ 96%]
tests/test_servicedesk.py::TestBasic::test_remove_users_from_organization PASSED                                                                [ 97%]
tests/test_servicedesk.py::TestBasic::test_get_customers PASSED                                                                                 [ 98%]
tests/test_servicedesk.py::TestBasic::test_add_customers PASSED                                                                                 [ 99%]
tests/test_servicedesk.py::TestBasic::test_remove_customers PASSED                                                                              [100%]

================================================================== warnings summary ===================================================================
tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_repositories
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:58: DeprecationWarning: Call to deprecated method get_repositories. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = [x["name"] for x in BITBUCKET.get_repositories("TestWorkspace1")]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipelines
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:62: DeprecationWarning: Call to deprecated method get_pipelines. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = [x["uuid"] for x in BITBUCKET.get_pipelines("TestWorkspace1", "testrepository1")]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_trigger_pipeline
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:66: DeprecationWarning: Call to deprecated method trigger_pipeline. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.trigger_pipeline("TestWorkspace1", "testrepository1")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:70: DeprecationWarning: Call to deprecated method get_pipeline. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.get_pipeline("TestWorkspace1", "testrepository1", "{PipelineUuid}")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_stop_pipeline
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:79: DeprecationWarning: Call to deprecated method stop_pipeline. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.stop_pipeline("TestWorkspace1", "testrepository1", "{PipelineUuid}")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_steps
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:84: DeprecationWarning: Call to deprecated method get_pipeline_steps. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    x["uuid"] for x in BITBUCKET.get_pipeline_steps("TestWorkspace1", "testrepository1", "{PipelineUuid}")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:89: DeprecationWarning: Call to deprecated method get_pipeline_step. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.get_pipeline_step(

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step_log_1
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:96: DeprecationWarning: Call to deprecated method get_pipeline_step_log. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.get_pipeline_step_log(

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_pipeline_step_log_2
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:102: DeprecationWarning: Call to deprecated method get_pipeline_step_log. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.get_pipeline_step_log(

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_issues
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:108: DeprecationWarning: Call to deprecated method get_issues. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = [x["title"] for x in BITBUCKET.get_issues("TestWorkspace1", "testrepository1")]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_create_issue
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:112: DeprecationWarning: Call to deprecated method create_issue. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.create_issue("TestWorkspace1", "testrepository1", "Title", "Description", "bug", "minor")[

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_issue
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:118: DeprecationWarning: Call to deprecated method get_issue. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.get_issue("TestWorkspace1", "testrepository1", 3)["kind"]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_update_issue
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:122: DeprecationWarning: Call to deprecated method update_issue. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.update_issue("TestWorkspace1", "testrepository1", 3, kind="enhancement")["kind"]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_issue
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:126: DeprecationWarning: Call to deprecated method delete_issue. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.delete_issue("TestWorkspace1", "testrepository1", 3)["title"]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_branch_restrictions
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:130: DeprecationWarning: Call to deprecated method get_branch_restrictions. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = [x["kind"] for x in BITBUCKET.get_branch_restrictions("TestWorkspace1", "testrepository1")]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_update_branch_restriction
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:140: DeprecationWarning: Call to deprecated method update_branch_restriction. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.update_branch_restriction("TestWorkspace1", "testrepository1", 17203842, branch="master")[

tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_branch_restriction
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:146: DeprecationWarning: Call to deprecated method delete_branch_restriction. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.delete_branch_restriction("TestWorkspace1", "testrepository1", 17203842)["pattern"]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_get_default_reviewers
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:150: DeprecationWarning: Call to deprecated method get_default_reviewers. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = [x["display_name"] for x in BITBUCKET.get_default_reviewers("TestWorkspace1", "testrepository1")]

tests/test_bitbucket_cloud_oo.py::TestBasic::test_is_default_reviewer
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:154: DeprecationWarning: Call to deprecated method is_default_reviewer. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.is_default_reviewer("TestWorkspace1", "testrepository1", "DefaultReviewerNo")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_is_default_reviewer
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:156: DeprecationWarning: Call to deprecated method is_default_reviewer. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.is_default_reviewer("TestWorkspace1", "testrepository1", "DefaultReviewer1Uuid")

tests/test_bitbucket_cloud_oo.py::TestBasic::test_delete_default_reviewer
  /Users/ashishpatel/workspace/atlassian-python-api/tests/test_bitbucket_cloud_oo.py:160: DeprecationWarning: Call to deprecated method delete_default_reviewer. (Use atlassian.bitbucket.cloud instead of atlassian.bitbucket) -- Deprecated since version 2.0.2.
    result = BITBUCKET.delete_default_reviewer("TestWorkspace1", "testrepository1", "DefaultReviewer1Uuid")[

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform darwin, python 3.11.4-final-0 ----------
Coverage XML written to file coverage.xml

===================================================== 111 passed, 6 skipped, 21 warnings in 3.16s =====================================================
py3: commands[2]> coverage html
Wrote HTML report to htmlcov/index.html
.pkg: _exit> python /Users/ashishpatel/workspace/atlassian-python-api/venv/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py3: OK ✔ in 37.03 seconds
flake8: install_deps> python -I -m pip install flake8
flake8: commands[0]> flake8 atlassian/ examples/ tests/
flake8: OK ✔ in 8.81 seconds
black: install_deps> python -I -m pip install black
black: commands[0]> black --check --diff atlassian/ examples/ tests/ --exclude __pycache__
Invalid config keys detected: 'include_trailing_comma' (in /Users/ashishpatel/workspace/atlassian-python-api/pyproject.toml)
All done! ✨ 🍰 ✨
243 files would be left unchanged.
black: OK ✔ in 14.69 seconds
mypy: install_deps> python -I -m pip install 'mypy>=0.812'
mypy: commands[0]> mypy --install-types --non-interactive atlassian/
Installing missing stub packages:
/Users/ashishpatel/workspace/atlassian-python-api/.tox/mypy/bin/python -m pip install types-Deprecated types-requests types-six

Collecting types-Deprecated
  Downloading types_Deprecated-1.2.9.20240106-py3-none-any.whl.metadata (1.6 kB)
Collecting types-requests
  Downloading types_requests-2.31.0.20240218-py3-none-any.whl.metadata (1.8 kB)
Collecting types-six
  Downloading types_six-1.16.21.20240106-py3-none-any.whl.metadata (1.5 kB)
Collecting urllib3>=2 (from types-requests)
  Using cached urllib3-2.2.1-py3-none-any.whl.metadata (6.4 kB)
Downloading types_Deprecated-1.2.9.20240106-py3-none-any.whl (3.5 kB)
Downloading types_requests-2.31.0.20240218-py3-none-any.whl (14 kB)
Downloading types_six-1.16.21.20240106-py3-none-any.whl (15 kB)
Using cached urllib3-2.2.1-py3-none-any.whl (121 kB)
Installing collected packages: urllib3, types-six, types-Deprecated, types-requests
Successfully installed types-Deprecated-1.2.9.20240106 types-requests-2.31.0.20240218 types-six-1.16.21.20240106 urllib3-2.2.1

Success: no issues found in 47 source files
mypy: OK ✔ in 27.76 seconds
bandit: install_deps> python -I -m pip install bandit 'importlib-metadata<=4.13.0'
bandit: commands[0]> bandit -r atlassian/
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.11.4
Run started:2024-02-23 12:57:27.326107

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 21347
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
bandit: OK ✔ in 17.47 seconds
doc8: install_deps> python -I -m pip install doc8 'importlib-metadata<=4.13.0' sphinx
doc8: commands[0]> doc8 --ignore-path docs/_build/ docs/
Scanning...
Validating...
========
Total files scanned = 9
Total files ignored = 0
Total accumulated errors = 0
Detailed error counts:
    - doc8.checks.CheckCarriageReturn = 0
    - doc8.checks.CheckIndentationNoTab = 0
    - doc8.checks.CheckMaxLineLength = 0
    - doc8.checks.CheckNewlineEndOfFile = 0
    - doc8.checks.CheckTrailingWhitespace = 0
    - doc8.checks.CheckValidity = 0
  py3: OK (37.03=setup[29.80]+cmd[0.84,3.91,2.49] seconds)
  flake8: OK (8.81=setup[6.83]+cmd[1.98] seconds)
  black: OK (14.69=setup[5.03]+cmd[9.66] seconds)
  mypy: OK (27.76=setup[11.46]+cmd[16.30] seconds)
  bandit: OK (17.47=setup[15.33]+cmd[2.14] seconds)
  doc8: OK (28.76=setup[27.40]+cmd[1.36] seconds)
  congratulations :) (134.63 seconds)
```