### PR TITLE
rest client: Only enable `backoff_and_retry` if `urllib3` is at least 2.0.0

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -13,6 +13,7 @@ from requests import HTTPError
 from requests_oauthlib import OAuth1, OAuth2
 from six.moves.urllib.parse import urlencode
 from urllib3.util import Retry
+import urllib3
 
 from atlassian.request_utils import get_default_logger
 
@@ -117,7 +118,7 @@ class AtlassianRestAPI(object):
             self._session = requests.Session()
         else:
             self._session = session
-        if backoff_and_retry:
+        if backoff_and_retry and int(urllib3.__version__.split(".")[0]) >= 2:
             # Note: we only retry on status and not on any of the
             # other supported reasons
             retries = Retry(


### PR DESCRIPTION
We are trying to use `backoff_and_retry` but are getting errors with urllib3 1.26.X this fixes and sets the minimum of `urllib3` to `>= 2.0.0`

The first release supporting `backoff_jitter` in the `Retry` class is the `2.0.0` release.

https://github.com/urllib3/urllib3/releases/tag/2.0.0

It doesn't look like this will be added to `1.26.X` https://github.com/urllib3/urllib3/pull/2952#issuecomment-1523888273
