### PR TITLE
Update GH Actions and fix NodeJS16 deprecation warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,4 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.11', '3.12' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Docker
         run: |
           make docker-qa-build PYTHON_VERSION=${{matrix.python-version}}
@@ -31,7 +31,7 @@ jobs:
           make docker-qa PYTHON_VERSION=${{matrix.python-version}}
       - name: Creating coverage report
         if: ${{ ( matrix.python-version == '3.8' ) }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
Updates all GH Actions to their latest release which fixes deprecation warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

### :boom: Breaking change

CodeCov introduced the requirement for an upload token ([breaking changes](https://github.com/codecov/codecov-action/blob/main/README.md#breaking-changes)). Please see [documentation](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions) or  [usage guide](https://github.com/codecov/codecov-action/blob/main/README.md#usage) for how to configure it.