### PR TITLE
[BitBucket] added new method get_groups + docs + examples

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -39,6 +39,26 @@ class Bitbucket(BitbucketBase):
     def _url_admin(self, api_version=None):
         return self.resource_url("admin", api_version=api_version)
 
+    def get_groups(self, group_filter=None, limit=25, start=0):
+        """
+        Get list of bitbucket groups.
+        Use 'group_filter' for get specific group or get all group if necessary.
+
+        :param group_filter: str - groupname
+        :param limit: int - paginated limit to retrieve
+        :param start: int - paginated point to start retrieving
+        :return: The collection as JSON with all relevant information about the group
+        """
+        url = self.resource_url("groups", api_version="1.0")
+        params = {}
+        if group_filter:
+            params["filter"] = group_filter
+        if limit:
+            params["limit"] = limit
+        if start:
+            params["start"] = start
+        return self._get_paged(url, params=params)
+
     def group_members(self, group, start=0, limit=None):
         """
         Get group of members

--- a/docs/bitbucket.rst
+++ b/docs/bitbucket.rst
@@ -160,6 +160,9 @@ Groups and admins
 
 .. code-block:: python
 
+    # Get groups. Use 'group_filter' parameter to get specific groups.
+    bitbucket.groups(group_filter="group", limit=99999)
+
     # Get group of members
     bitbucket.group_members(group, limit=99999)
 

--- a/examples/bitbucket/bitbucket_groups.py
+++ b/examples/bitbucket/bitbucket_groups.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+from atlassian import Bitbucket
+
+bitbucket = Bitbucket(url="http://localhost:7990", username="admin", password="admin")
+
+data = bitbucket.get_groups(group_filter="group")
+print(data)


### PR DESCRIPTION
added a new method to the Bitbuckets get_groups which:

* Takes a  display name for the group as input.
* Returns a list of user groups.