### PR TITLE
fix missing error msg

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -537,7 +537,9 @@ class AtlassianRestAPI(object):
                 else:
                     error_msg_list = j.get("errorMessages", list())
                     errors = j.get("errors", dict())
-                    if isinstance(errors, dict):
+                    if isinstance(errors, dict) and "message" not in errors:
+                        error_msg_list.extend(errors.values())
+                    elif isinstance(errors, dict) and "message" in errors:
                         error_msg_list.append(errors.get("message", ""))
                     elif isinstance(errors, list):
                         error_msg_list.extend([v.get("message", "") if isinstance(v, dict) else v for v in errors])


### PR DESCRIPTION
This PR fixes missing JIRA error msg, related to #1363

Error handling can also be simplified as follows:

```python
if 400 <= response.status_code < 600:
    raise HTTPError(response.text, response=response)
else:
    response.raise_for_status()
```