### PR TITLE
[Confluence] Expand parameter addition for get_draft_page_by_id

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -506,17 +506,18 @@ class Confluence(AtlassianRestAPI):
 
         return response
 
-    def get_draft_page_by_id(self, page_id, expand=None):
+    def get_draft_page_by_id(self, page_id, status='draft', expand=None):
         """
         Gets content by id with status = draft
         :param page_id: Content ID
+        :param status: (str) list of content statuses to filter results on. Default value: [draft]
         :param expand: OPTIONAL: Default value: history,space,version
                        We can also specify some extensions such as extensions.inlineProperties
                        (for getting inline comment-specific properties) or extensions. Resolution
                        for the resolution status of each comment in the results
         :return:
         """
-        # Status hardcoded to draft, version not passed since draft versions
+        # Version not passed since draft versions don't match the page and
         # operate differently between different collaborative modes
         return self.get_page_by_id(page_id=page_id, expand=expand, status='draft')
 

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -506,7 +506,7 @@ class Confluence(AtlassianRestAPI):
 
         return response
 
-    def get_draft_page_by_id(self, page_id, status='draft', expand=None):
+    def get_draft_page_by_id(self, page_id, status="draft", expand=None):
         """
         Gets content by id with status = draft
         :param page_id: Content ID

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -519,7 +519,7 @@ class Confluence(AtlassianRestAPI):
         """
         # Version not passed since draft versions don't match the page and
         # operate differently between different collaborative modes
-        return self.get_page_by_id(page_id=page_id, expand=expand, status='draft')
+        return self.get_page_by_id(page_id=page_id, expand=expand, status=status)
 
     def get_all_pages_by_label(self, label, start=0, limit=50):
         """

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -506,27 +506,19 @@ class Confluence(AtlassianRestAPI):
 
         return response
 
-    def get_draft_page_by_id(self, page_id, status="draft"):
+    def get_draft_page_by_id(self, page_id, expand=None):
         """
-        Provide content by id with status = draft
-        :param page_id:
-        :param status:
+        Gets content by id with status = draft
+        :param page_id: Content ID
+        :param expand: OPTIONAL: Default value: history,space,version
+                       We can also specify some extensions such as extensions.inlineProperties
+                       (for getting inline comment-specific properties) or extensions. Resolution
+                       for the resolution status of each comment in the results
         :return:
         """
-        url = "rest/api/content/{page_id}?status={status}".format(page_id=page_id, status=status)
-
-        try:
-            response = self.get(url)
-        except HTTPError as e:
-            if e.response.status_code == 404:
-                raise ApiPermissionError(
-                    "The calling user does not have permission to view the content",
-                    reason=e,
-                )
-
-            raise
-
-        return response
+        # Status hardcoded to draft, version not passed since draft versions
+        # operate differently between different collaborative modes
+        return self.get_page_by_id(page_id=page_id, expand=expand, status='draft')
 
     def get_all_pages_by_label(self, label, start=0, limit=50):
         """

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1355,7 +1355,7 @@ class Jira(AtlassianRestAPI):
         else:
             new_value = [value]
 
-        fields = {'{}'.format(field): new_value}
+        fields = {"{}".format(field): new_value}
 
         return self.put(
             "{base_url}/{key}".format(base_url=base_url, key=issue_id_or_key),


### PR DESCRIPTION
`get_draft_page_by_id` calls the same endpoint as `get_page_by_id` but with the status defaulted to `draft`. Updated the underlying function to just forward the params to `get_page_by_id` which allows the `expand` and `version` parameter to be passed as well, though I only added the `expand` parameter to `get_draft_page_by_id` since the versioning is a bit different than the standard page versioning.