### PR TITLE
Remove broken 'author' parameter in Bamboo create_comment

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -685,19 +685,17 @@ class Bamboo(AtlassianRestAPI):
         params = {"start-index": start_index, "max-results": max_results}
         return self.get(self.resource_url(resource), params=params)
 
-    def create_comment(self, project_key, plan_key, build_number, comment, author=None):
+    def create_comment(self, project_key, plan_key, build_number, comment):
         """
         Create a comment for a specific build
         :param project_key:
         :param plan_key:
         :param build_number:
         :param comment:
-        :param author:
         :return:
         """
         resource = "result/{}-{}-{}/comment".format(project_key, plan_key, build_number)
         comment_data = {
-            "author": author if author else self.username,
             "content": comment,
         }
         return self.post(self.resource_url(resource), data=comment_data)

--- a/docs/bamboo.rst
+++ b/docs/bamboo.rst
@@ -108,7 +108,7 @@ Comments & Labels
     comments(project_key, plan_key, build_number, start_index=0, max_results=25)
 
     # Create a comment for a specific build
-    create_comment(project_key, plan_key, build_number, comment, author=None)
+    create_comment(project_key, plan_key, build_number, comment)
 
     # Get labels for a build
     labels(project_key, plan_key, build_number, start_index=0, max_results=25)


### PR DESCRIPTION
The Bamboo `create_comment` function does not work, returning an error that the `author` field is unrecognized and invalid. The field should be removed to fix the behavior.

We can also see that the `author` field is not present in the documented API, linked below:
https://developer.atlassian.com/server/bamboo/rest/api-group-api/#api-api-latest-result-projectkey-buildkey-buildnumber-comment-post

Making this change allows posting comments, as expected.