### PR TITLE
Remove unused kwarg

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2434,7 +2434,6 @@ class Jira(AtlassianRestAPI):
                 self._get_paged(
                     self.resource_url("project/search"),
                     params,
-                    paging_workaround=True,
                 )
             )
         else:


### PR DESCRIPTION
The argument `paging_workaround` was added by accident. Remove it.

Close #1397 