### PR TITLE
Verification Handling for Attachment Download from Confluence

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1336,7 +1336,7 @@ class Confluence(AtlassianRestAPI):
                 if not file_name:
                     file_name = attachment["id"]  # if the attachment has no title, use attachment_id as a filename
                 download_link = self.url + attachment["_links"]["download"]
-                r = self._session.get(f"{download_link}")
+                r = self._session.get(f"{download_link}",verify=self.verify_ssl)
                 file_path = os.path.join(path, file_name)
                 with open(file_path, "wb") as f:
                     f.write(r.content)


### PR DESCRIPTION
Even if the Confluence Client is instantiated with verify_ssl=False the Attachment Download stills breaks at the verification stage since the method uses the get method from the request session.

Workaround from my side is to add the verification in the get call. 

Otherwise great work!