### PR TITLE
Fixed confluence add_user_group to use right URL

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -3067,10 +3067,8 @@ class Confluence(AtlassianRestAPI):
         :param group_name: str - name of group to add user to
         :return: Current state of the group
         """
-        url = "rest/api/2/group/user"
-        params = {"groupname": group_name}
-        data = {"name": username}
-        return self.post(url, params=params, data=data)
+       url = f"rest/api/user/{username}/group/{group_name}"
+       return self.put(url)
 
     def add_space_permissions(
         self,

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -3067,8 +3067,8 @@ class Confluence(AtlassianRestAPI):
         :param group_name: str - name of group to add user to
         :return: Current state of the group
         """
-       url = f"rest/api/user/{username}/group/{group_name}"
-       return self.put(url)
+        url = f"rest/api/user/{username}/group/{group_name}"
+        return self.put(url)
 
     def add_space_permissions(
         self,


### PR DESCRIPTION
Rel: https://github.com/atlassian-api/atlassian-python-api/issues/1422
The URL of the confluence REST API was wrong in add_user_group and it has to be a PUT request according to: 

[https://docs.atlassian.com/ConfluenceServer/rest/8.2.0/#api/user/{username}/group/{groupName}-update](https://docs.atlassian.com/ConfluenceServer/rest/8.2.0/#api/user/%7Busername%7D/group/%7BgroupName%7D-update)