### PR TITLE
revoked PR

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -284,11 +284,11 @@ class Jira(AtlassianRestAPI):
         """
         Returns the content for an attachment
         :param attachment_id: int
-        :return: json
+        :return: content as bytes
         """
         base_url = self.resource_url("attachment")
         url = "{base_url}/content/{attachment_id}".format(base_url=base_url, attachment_id=attachment_id)
-        return self.get(url)
+        return self.get(url, not_json_response=True)
 
     def remove_attachment(self, attachment_id):
         """


### PR DESCRIPTION
### Problem / Observation

Using the method `get_attachment_content()` returns a `str` of the content, which corrupts the actual content bytes due to encoding issues.

#### Usage example (problem showcase)
Assuming, there's a PNG image attached to a ticket, in my use case I want to download the PNG image.
```python
content = jira.get_attachment_content(12345)
with open("content.png", 'wb') as f:
    f.write(content)
```
This leads to a runtime exception: `a bytes-like object is required, not 'str'`
IF I try to use text file mode `open("content.png", 'w')` then the content is broken due to utf-8 encoding, which is obviously not required, but used due to the fact the content object type is `str`.

### Fix

Don't convert an attachment content into a string, e.g. using `self.get(url, not_json_response=True)`

### Impact

* This PR fixes the issue for all binary attachments and is the correct way how to handle binary attachments - that said, text attachments will work as well.
* This PR potentially breaks existing integration, IF people tried to use character encoding and somehow build workarounds - chances are minor IMHO, as I was not able to build a workaround for binary data, and only could imagine encoding-workarounds for textual attachments.

# Context
* manually tested with Python 3.12 on Mac OSX (Apple silicon)