### PR TITLE
Bitbucket: fix merge_pull_request. POST`params` --> `data`

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2231,7 +2231,8 @@ class Bitbucket(BitbucketBase):
         :return:
         """
         url = "{}/merge".format(self._url_pull_request(project_key, repository_slug, pr_id))
-        params = {
+        params = {}
+        data = {
             "type": "pullrequest",
             "message": merge_message,
             "close_source_branch": close_source_branch,
@@ -2239,7 +2240,7 @@ class Bitbucket(BitbucketBase):
         }
         if not self.cloud:
             params["version"] = pr_version
-        return self.post(url, data=params)
+        return self.post(url, data=data, params=params)
 
     def reopen_pull_request(self, project_key, repository_slug, pr_id, pr_version):
         """

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2211,10 +2211,10 @@ class Bitbucket(BitbucketBase):
         project_key: str,
         repository_slug: str,
         pr_id: int,
-        pr_version: Optional[int],
         merge_message: str,
         close_source_branch: bool = False,
         merge_strategy: Union[str, MergeStrategy] = MergeStrategy.MERGE_COMMIT,
+        pr_version: Optional[int] = None,
     ):
         """
         Merge pull request
@@ -2224,21 +2224,22 @@ class Bitbucket(BitbucketBase):
         :param project_key: PROJECT
         :param repository_slug: my_shiny_repo
         :param pr_id: 2341
-        :param pr_version:
         :param merge_message: "feat: add new file handler"
+        :param pr_version:
         :param close_source_branch: True
         :param merge_strategy:  "squash"
         :return:
         """
         url = "{}/merge".format(self._url_pull_request(project_key, repository_slug, pr_id))
         params = {
+            "type": "pullrequest",
             "message": merge_message,
             "close_source_branch": close_source_branch,
             "merge_strategy": MergeStrategy(merge_strategy).value,
         }
         if not self.cloud:
             params["version"] = pr_version
-        return self.post(url, params=params)
+        return self.post(url, data=params)
 
     def reopen_pull_request(self, project_key, repository_slug, pr_id, pr_version):
         """


### PR DESCRIPTION
Hello there 🖖 

I was testing this in my local and Bitbucket Cloud was raising an error code whenever I tried to merge a PR.
Wanted to maintain previous version and did not notice that `params` dict was being sent as URL encoded params. The new params should be a JSON encoded body for the POST request instead --> [source](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-merge-post)

I've fixed it and tested with my own repositories in Bitbucket Cloud 👍 

QA:
```Markdown
doc8: commands[0]> doc8 --ignore-path docs/_build/ docs/
Scanning...
Validating...
========
Total files scanned = 9
Total files ignored = 0
Total accumulated errors = 0
Detailed error counts:
    - doc8.checks.CheckCarriageReturn = 0
    - doc8.checks.CheckIndentationNoTab = 0
    - doc8.checks.CheckMaxLineLength = 0
    - doc8.checks.CheckNewlineEndOfFile = 0
    - doc8.checks.CheckTrailingWhitespace = 0
    - doc8.checks.CheckValidity = 0
  py3: OK (9.81=setup[5.23]+cmd[0.14,2.34,2.10] seconds)
  flake8: OK (1.48=setup[0.01]+cmd[1.47] seconds)
  black: OK (2.16=setup[0.01]+cmd[2.15] seconds)
  mypy: OK (0.85=setup[0.01]+cmd[0.84] seconds)
  bandit: OK (1.83=setup[0.01]+cmd[1.82] seconds)
  doc8: OK (0.86=setup[0.01]+cmd[0.85] seconds)
  congratulations :) (17.14 seconds)
```