### PR TITLE
Continue to support Python 2

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2208,13 +2208,13 @@ class Bitbucket(BitbucketBase):
 
     def merge_pull_request(
         self,
-        project_key: str,
-        repository_slug: str,
-        pr_id: int,
-        merge_message: str,
-        close_source_branch: bool = False,
-        merge_strategy: Union[str, MergeStrategy] = MergeStrategy.MERGE_COMMIT,
-        pr_version: Optional[int] = None,
+        project_key,
+        repository_slug,
+        pr_id,
+        merge_message,
+        close_source_branch=False,
+        merge_strategy=MergeStrategy.MERGE_COMMIT,
+        pr_version=None,
     ):
         """
         Merge pull request

--- a/atlassian/bitbucket/cloud/repositories/__init__.py
+++ b/atlassian/bitbucket/cloud/repositories/__init__.py
@@ -263,8 +263,8 @@ class Repository(BitbucketCloudBase):
         self.__hooks = Hooks(
             "{}/hooks".format(self.url),
             data={"links": {"hooks": {"href": "{}/hooks".format(self.url)}}},
-            **self._new_session_args,
-        )
+            **self._new_session_args
+        )  # fmt: skip
         self.__default_reviewers = DefaultReviewers("{}/default-reviewers".format(self.url), **self._new_session_args)
         self.__deployment_environments = DeploymentEnvironments(
             "{}/environments".format(self.url), **self._new_session_args

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1340,7 +1340,7 @@ class Confluence(AtlassianRestAPI):
                 if not file_name:
                     file_name = attachment["id"]  # if the attachment has no title, use attachment_id as a filename
                 download_link = self.url + attachment["_links"]["download"]
-                r = self._session.get(f"{download_link}")
+                r = self._session.get(download_link)
                 file_path = os.path.join(path, file_name)
                 with open(file_path, "wb") as f:
                     f.write(r.content)
@@ -2922,7 +2922,7 @@ class Confluence(AtlassianRestAPI):
 
     def get_whiteboard(self, whiteboard_id):
         try:
-            url = f"/api/v2/whiteboards/{whiteboard_id}"
+            url = "/api/v2/whiteboards/%s" % (whiteboard_id)
             return self.get(url)
         except HTTPError as e:
             # Default 404 error handling is ambiguous
@@ -2935,7 +2935,7 @@ class Confluence(AtlassianRestAPI):
 
     def delete_whiteboard(self, whiteboard_id):
         try:
-            url = f"/api/v2/whiteboards/{whiteboard_id}"
+            url = "/api/v2/whiteboards/%s" % (whiteboard_id)
             return self.delete(url)
         except HTTPError as e:
             # # Default 404 error handling is ambiguous
@@ -3071,7 +3071,7 @@ class Confluence(AtlassianRestAPI):
         :param group_name: str - name of group to add user to
         :return: Current state of the group
         """
-        url = f"rest/api/user/{username}/group/{group_name}"
+        url = "rest/api/user/%s/group/%s" % (username, group_name)
         return self.put(url)
 
     def add_space_permissions(

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -255,11 +255,11 @@ class Jira(AtlassianRestAPI):
                 path = os.getcwd()
             issue_id = self.issue(issue, fields="id")["id"]
             if cloud:
-                url = self.url + f"/secure/issueAttachments/{issue_id}.zip"
+                url = self.url + "/secure/issueAttachments/%s.zip" % (issue_id)
             else:
-                url = self.url + f"/secure/attachmentzip/{issue_id}.zip"
+                url = self.url + "/secure/attachmentzip/%s.zip" % (issue_id)
             response = self._session.get(url)
-            attachment_name = f"{issue_id}_attachments.zip"
+            attachment_name = "%s_attachments.zip" % (issue_id)
             file_path = os.path.join(path, attachment_name)
             # if Jira issue doesn't have any attachments _session.get request response will return 22 bytes of PKzip format
             file_size = sum(len(chunk) for chunk in response.iter_content(8196))


### PR DESCRIPTION
Avoid Python 3-only capabilities:
- Remove f-strings (jira.py, confluence.py)
- Remove type specifications (bitbucket)
- Remove trailing commas (bitbucket)