### PR TITLE
Add: Remote link: Application

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1776,6 +1776,7 @@ class Jira(AtlassianRestAPI):
         icon_url=None,
         icon_title=None,
         status_resolved=False,
+        application: dict = {},
     ):
         """
         Add Remote Link to Issue, update url if global_id is passed
@@ -1787,6 +1788,7 @@ class Jira(AtlassianRestAPI):
         :param icon_url: str, OPTIONAL: Link to a 16x16 icon representing the type of the object in the remote system
         :param icon_title: str, OPTIONAL: Text for the tooltip of the main icon describing the type of the object in the remote system
         :param status_resolved: bool, OPTIONAL: if set to True, Jira renders the link strikethrough
+        :param application: dict, OPTIONAL: Application description
         """
         base_url = self.resource_url("issue")
         url = "{base_url}/{issue_key}/remotelink".format(base_url=base_url, issue_key=issue_key)
@@ -1802,6 +1804,8 @@ class Jira(AtlassianRestAPI):
             if icon_title:
                 icon_data["title"] = icon_title
             data["object"]["icon"] = icon_data
+        if application:
+            data["application"] = application
         return self.post(url, data=data)
 
     def get_issue_remote_link_by_id(self, issue_key, link_id):

--- a/tests/responses/jira/rest/api/2/issue/FOO-123/remotelink/POST
+++ b/tests/responses/jira/rest/api/2/issue/FOO-123/remotelink/POST
@@ -1,0 +1,7 @@
+responses[
+    '{"object": {"url": "https://confluence.atlassian-python.atlassian.net/display/Test", "title": "Unused link text", "status": {"resolved": false}}}'
+] = {
+    "id": 10000,
+    "self": "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000",
+    "application": {},
+}

--- a/tests/responses/jira/rest/api/2/issue/FOO-123/remotelink/POST
+++ b/tests/responses/jira/rest/api/2/issue/FOO-123/remotelink/POST
@@ -5,3 +5,13 @@ responses[
     "self": "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000",
     "application": {},
 }
+responses[
+    '{"object": {"url": "https://confluence.atlassian-python.atlassian.net/display/Test", "title": "Unused link text", "status": {"resolved": false}}, "globalId": "appId=00000000-0000-0000-0000-000000000000&pageId=0", "application": {"type": "com.atlassian.confluence", "name": "Confluence"}}'
+] = {
+    "id": 10000,
+    "self": "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000",
+    "application": {
+        "type": "com.atlassian.confluence",
+        "name": "Confluence",
+    },
+}

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -105,3 +105,27 @@ class TestJira(TestCase):
             resp["self"], "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000"
         )
         self.assertDictEqual(resp["application"], {})
+
+    def test_post_issue_remotelink_confluence(self):
+        """Create a new Confluence remote link"""
+        resp = self.jira.create_or_update_issue_remote_links(
+            "FOO-123",
+            "https://confluence.atlassian-python.atlassian.net/display/Test",
+            "Unused link text",
+            global_id="appId=00000000-0000-0000-0000-000000000000&pageId=0",
+            application={
+                "type": "com.atlassian.confluence",
+                "name": "Confluence",
+            },
+        )
+        self.assertEqual(resp["id"], 10000)
+        self.assertEqual(
+            resp["self"], "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000"
+        )
+        self.assertDictEqual(
+            resp["application"],
+            {
+                "type": "com.atlassian.confluence",
+                "name": "Confluence",
+            },
+        )

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -92,3 +92,16 @@ class TestJira(TestCase):
             self.jira.get_issue_property("FOO-123", "NotFoundBar1")
         with self.assertRaises(HTTPError):
             self.jira.get_issue_property("FOONotFound-123", "NotFoundBar1")
+
+    def test_post_issue_remotelink(self):
+        """Create a new remote link"""
+        resp = self.jira.create_or_update_issue_remote_links(
+            "FOO-123",
+            "https://confluence.atlassian-python.atlassian.net/display/Test",
+            "Unused link text",
+        )
+        self.assertEqual(resp["id"], 10000)
+        self.assertEqual(
+            resp["self"], "https://atlassian-python.atlassian.net/rest/api/2/issue/FOO-123/remotelink/10000"
+        )
+        self.assertDictEqual(resp["application"], {})


### PR DESCRIPTION
Fixes #1448, Replaces #1429

Adding a link to an application connected with a Jira instance through the `/rest/api/2/issue/{issueIdOrKey}/remotelink` Jira API route, an `application` section might be provided.
This might for instance be used to add Confluence links to a connected Confluence instance.
Cf. [Atlassian knowledge base about the different kind of links](https://confluence.atlassian.com/jirakb/how-to-use-rest-api-to-add-remote-links-in-jira-issues-1206556936.html).

This PR add an `application` parameter to the `create_or_update_issue_remote_links` function.