### PR TITLE
Infrastructure: `make docker-fmt` for invoking black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ docker-qa-build: Dockerfile.qa requirements.txt requirements-dev.txt
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--file $< .
 
+docker-fmt: docker-qa-build
+	docker run --rm -v `pwd`:/atlassian-python-api $(QA_CONTAINER) tox -e black_fmt
+
 docker-atlassian-standalone: Dockerfile.standalone
 	docker build \
 		--tag $(ATLASSIAN_SDK) \

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,13 @@ skip_install = true
 deps = black
 commands = black --check --diff {[base]linting_targets} --exclude __pycache__
 
+[testenv:black_fmt]
+basepython = python3
+target-version = ["py37"]
+skip_install = true
+deps = black
+commands = black {[base]linting_targets} --exclude __pycache__
+
 [testenv:mypy]
 basepython = python3
 skip_install = true


### PR DESCRIPTION
As mentioned in #1460 here's a PR adding the `docker-fmt` target to make for invoking black more easily