### PR TITLE
Improved download_attachments_from_page: added filename filter for si…

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1400,14 +1400,14 @@ class Confluence(AtlassianRestAPI):
             comment=comment,
         )
 
-    def download_attachments_from_page(self, page_id, save_path=None, start=0, limit=50, filename=None, to_memory=False):
+    def download_attachments_from_page(self, page_id, path=None, start=0, limit=50, filename=None, to_memory=False):
         """
         Downloads attachments from a Confluence page. Supports downloading all files or a specific file. 
         Files can either be saved to disk or returned as BytesIO objects for in-memory handling.
 
         :param page_id: str
             The ID of the Confluence page to fetch attachments from.
-        :param save_path: str, optional
+        :param path: str, optional
             Directory where attachments will be saved. If None, defaults to the current working directory.
             Ignored if `to_memory` is True.
         :param start: int, optional
@@ -1423,14 +1423,14 @@ class Confluence(AtlassianRestAPI):
             - If `to_memory` is True, returns a dictionary {filename: BytesIO object}.
             - If `to_memory` is False, returns a summary dict: {"attachments_downloaded": int, "path": str}.
         :raises:
-            - FileNotFoundError: If the specified save_path does not exist.
-            - PermissionError: If there are permission issues with the specified save_path.
+            - FileNotFoundError: If the specified path does not exist.
+            - PermissionError: If there are permission issues with the specified path.
             - requests.HTTPError: If the HTTP request to fetch an attachment fails.
             - Exception: For any unexpected errors.
         """
-        # Default save_path to current working directory if not provided
-        if not to_memory and save_path is None:
-            save_path = os.getcwd()
+        # Default path to current working directory if not provided
+        if not to_memory and path is None:
+            path = os.getcwd()
 
         try:
             # Fetch attachments based on the specified parameters
@@ -1461,7 +1461,7 @@ class Confluence(AtlassianRestAPI):
                     downloaded_files[file_name] = file_obj
                 else:
                     # Save file to disk
-                    file_path = os.path.join(save_path, file_name)
+                    file_path = os.path.join(path, file_name)
                     with open(file_path, "wb") as file:
                         file.write(response.content)
 
@@ -1469,12 +1469,12 @@ class Confluence(AtlassianRestAPI):
             if to_memory:
                 return downloaded_files
             else:
-                return {"attachments_downloaded": len(attachments), "path": save_path}
+                return {"attachments_downloaded": len(attachments), "path": path}
 
         except NotADirectoryError:
-            raise FileNotFoundError(f"The directory '{save_path}' does not exist.")
+            raise FileNotFoundError(f"The directory '{path}' does not exist.")
         except PermissionError:
-            raise PermissionError(f"Permission denied when trying to save files to '{save_path}'.")
+            raise PermissionError(f"Permission denied when trying to save files to '{path}'.")
         except requests.HTTPError as http_err:
             raise Exception(f"HTTP error occurred while downloading attachments: {http_err}")
         except Exception as err:


### PR DESCRIPTION
Here’s an improved and generalized version of your pull request comment:

---

### **NEW/CHANGE**:
#### **`download_attachments_from_page` Method in `confluence.py`**
- **Backward Compatibility**: The existing usage of this method remains unchanged, and can be used as previous for downloading all attachments on page.
- **New Features**:
  1. **Download by Filename**: Added the `filename` parameter to enable downloading a specific file by its name. This avoids the need to process all attachments when only one file is required.
  2. **In-Memory Downloads**: Introduced the `to_memory` parameter. When set to `True`, files are downloaded as `BytesIO` objects instead of being written to disk. This is particularly useful when files are passed directly into other pipelines, such as `pandas`, without intermediate storage.

#### **Example Use Case**:
```python
from atlassian import Confluence
import pandas as pd

# Initialize Confluence client
confluence = Confluence(
    url=base_url,
    token=open(token_path, 'r').read().strip(),
)

# Retrieve the page ID
page_id = confluence.get_page_id("some_space", "some_page")

# Download a specific file directly into memory
file_name = "excel_file.xlsx"
file_data = confluence.download_attachments_from_page(page_id=page_id, filename=file_name, to_memory=True)

# Process the file using pandas
excel_data = pd.read_excel(io=file_data.get(file_name))

# Output: DataFrame ready for use in further analysis
print(excel_data)
```

---

### **Other Changes**:
- **PEP-8 Compliance**: Reorganized imports in `confluence.py`:
  - Alphabetically ordered standard library, third-party, and local imports.
---
