### PR TITLE
[Atlassian] Issue of not using proxies inside rest client session

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -121,8 +121,7 @@ class AtlassianRestAPI(object):
             self._session = session
 
         if proxies is not None:
-            self._session.proxies = self.proxies
-            
+            self._session.proxies = self.proxies  
         if backoff_and_retry and int(urllib3.__version__.split(".")[0]) >= 2:
             # Note: we only retry on status and not on any of the
             # other supported reasons

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -119,6 +119,10 @@ class AtlassianRestAPI(object):
             self._session = requests.Session()
         else:
             self._session = session
+
+        if proxies is not None:
+            self._session.proxies = self.proxies
+            
         if backoff_and_retry and int(urllib3.__version__.split(".")[0]) >= 2:
             # Note: we only retry on status and not on any of the
             # other supported reasons

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -121,7 +121,8 @@ class AtlassianRestAPI(object):
             self._session = session
 
         if proxies is not None:
-            self._session.proxies = self.proxies  
+            self._session.proxies = self.proxies
+
         if backoff_and_retry and int(urllib3.__version__.split(".")[0]) >= 2:
             # Note: we only retry on status and not on any of the
             # other supported reasons


### PR DESCRIPTION
Adds the provided proxies to the request session after creation.
Without this the proxies will not be used to download attachements for example.