### PR TITLE
[Jira] Fix Jira archive project REST API method from POST to PUT

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -2508,7 +2508,7 @@ class Jira(AtlassianRestAPI):
         """
         base_url = self.resource_url("project")
         url = "{base_url}/{key}/archive".format(base_url=base_url, key=key)
-        return self.post(url)
+        return self.put(url)
 
     def project(self, key, expand=None):
         """


### PR DESCRIPTION
https://docs.atlassian.com/software/jira/docs/api/REST/9.14.0/#api/2/project-archiveProject

In the latest Jira LTS versions (9.12, 9.4), a 405 error occurs with the "HTTP request Wrong method" when using the Archive Project function.

Upon investigation, it was found that the method was incorrectly set to POST. This will be corrected to use PUT instead.