### PR TITLE
[XRAY] add get_test_run_iteration method and add more meaningful error raising for incorrect token in XRAY

### DIFF
--- a/atlassian/xray.py
+++ b/atlassian/xray.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import logging
 import re
+from requests import HTTPError
 from .rest_client import AtlassianRestAPI
 
 log = logging.getLogger(__name__)
@@ -12,6 +13,25 @@ class Xray(AtlassianRestAPI):
             kwargs["api_version"] = "1.0"
         kwargs["api_root"] = "rest/raven"
         super(Xray, self).__init__(*args, **kwargs)
+
+    def raise_for_status(self, response):
+        """
+        Checks the response for an error status and raises an exception with the error message provided by the server
+        :param response:
+        :return:
+        """
+        if response.status_code == 401 and response.headers.get("Content-Type") != "application/json;charset=UTF-8":
+            raise HTTPError("Unauthorized (401)", response=response)
+
+        if 400 <= response.status_code < 600:
+            try:
+                j = response.json()
+                error_msg = j["message"]
+            except Exception as e:
+                log.error(e)
+                response.raise_for_status()
+            else:
+                raise HTTPError(error_msg, response=response)
 
     def resource_url(self, resource, api_root=None, api_version=None):
         """

--- a/atlassian/xray.py
+++ b/atlassian/xray.py
@@ -463,6 +463,16 @@ class Xray(AtlassianRestAPI):
         url = self.resource_url("testrun/{0}".format(test_run_id))
         return self.put(url, update)
 
+    def get_test_run_iteration(self, test_run_id, iteration_id):
+        """
+        Retrieve the specified iteration for the given test run.
+        :param test_run_id: ID of the test run (e.g. 100).
+        :param iteration_id: ID of the iteration.
+        :return: Returns the specified iteration for the given test run.
+        """
+        url = self.resource_url("testrun/{0}/iteration/{1}".format(test_run_id, iteration_id))
+        return self.get(url)
+
     def get_test_run_status(self, test_run_id):
         """
         Retrieve the status for the given test run.

--- a/docs/xray.rst
+++ b/docs/xray.rst
@@ -136,6 +136,9 @@ Manage Test Runs
     # Update the assignee for the given test run
     xray.update_test_run_assignee(100, 'bob')
 
+    # Retrieve a iteration of the given test run
+    xray.get_test_run_iteration(100, 200)
+
     # Retrieve the status for the given test run
     xray.get_test_run_status(100)
 


### PR DESCRIPTION
When my token is incorrect in XRAY, it raises a requests.exceptions.HTTPError, leaving me guessing as to where I go wrong. This could solve #1059 and #1159 , but I haven't got much information on these issues. Also, I'm unaware as to if the error is spread over more components, I only have experienced it in XRAY.

I also think the get_test_run_iteration method is necessary to get specific step information, such as parameters, etc. which the get_test_runs_in_context doesn't get when the iterations are above one.