### PR TITLE
[Bitbucket] keep only 6 digits when using %f in datetime format

### DIFF
--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -32,7 +32,7 @@ class BitbucketBase(AtlassianRestAPI):
                 url = url[0]
         self.timeformat_lambda = kwargs.pop("timeformat_lambda", self._default_timeformat_lambda)
         self._check_timeformat_lambda()
-        super(BitbucketBase, self).__init__(url, *args, **kwargs)
+        super().__init__(url, *args, **kwargs)
 
     def __str__(self):
         return PrettyPrinter(indent=4).pformat(self.__data if self.__data else self)
@@ -74,8 +74,7 @@ class BitbucketBase(AtlassianRestAPI):
             if "values" not in response:
                 return
 
-            for value in response.get("values", []):
-                yield value
+            yield from response.get("values", [])
 
             if self.cloud:
                 url = response.get("next")
@@ -197,10 +196,10 @@ class BitbucketBase(AtlassianRestAPI):
 
         :return: A dict with the kwargs for new objects
         """
-        return dict(
-            session=self._session,
-            cloud=self.cloud,
-            api_root=self.api_root,
-            api_version=self.api_version,
-            timeformat_lambda=self.timeformat_lambda,
-        )
+        return {
+            "session": self._session,
+            "cloud": self.cloud,
+            "api_root": self.api_root,
+            "api_version": self.api_version,
+            "timeformat_lambda": self.timeformat_lambda,
+        }

--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -30,7 +30,9 @@ class BitbucketBase(AtlassianRestAPI):
             url = self.get_link("self")
             if isinstance(url, list):  # Server has a list of links
                 url = url[0]
-        self.timeformat_lambda = kwargs.pop("timeformat_lambda", lambda x: self._default_timeformat_lambda(x))
+        self.timeformat_lambda = kwargs.pop(
+            "timeformat_lambda", lambda x: self._default_timeformat_lambda(x)
+        )
         self._check_timeformat_lambda()
         super(BitbucketBase, self).__init__(url, *args, **kwargs)
 
@@ -111,7 +113,8 @@ class BitbucketBase(AtlassianRestAPI):
         """
         LAMBDA = lambda: 0  # noqa: E731
         if self.timeformat_lambda is None or (
-            isinstance(self.timeformat_lambda, type(LAMBDA)) and self.timeformat_lambda.__name__ == LAMBDA.__name__
+            isinstance(self.timeformat_lambda, type(LAMBDA))
+            and self.timeformat_lambda.__name__ == LAMBDA.__name__
         ):
             return True
         else:
@@ -165,9 +168,13 @@ class BitbucketBase(AtlassianRestAPI):
             if sys.version_info <= (3, 7):
                 value_str = RE_TIMEZONE.sub(r"\1\2", value_str)
             try:
+                value_str = value_str[:26] + "Z"
                 value = datetime.strptime(value_str, self.CONF_TIMEFORMAT)
             except ValueError:
-                value = datetime.strptime(value_str, "%Y-%m-%dT%H:%M:%S.%fZ", tzinfo="UTC")
+                value = datetime.strptime(
+                    value_str,
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                )
         else:
             value = value_str
 

--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -110,8 +110,7 @@ class BitbucketBase(AtlassianRestAPI):
         """
         LAMBDA = lambda: 0  # noqa: E731
         if self.timeformat_lambda is None or (
-            isinstance(self.timeformat_lambda, type(LAMBDA))
-            and self.timeformat_lambda.__name__ == LAMBDA.__name__
+            isinstance(self.timeformat_lambda, type(LAMBDA)) and self.timeformat_lambda.__name__ == LAMBDA.__name__
         ):
             return True
         else:

--- a/atlassian/bitbucket/base.py
+++ b/atlassian/bitbucket/base.py
@@ -30,9 +30,7 @@ class BitbucketBase(AtlassianRestAPI):
             url = self.get_link("self")
             if isinstance(url, list):  # Server has a list of links
                 url = url[0]
-        self.timeformat_lambda = kwargs.pop(
-            "timeformat_lambda", lambda x: self._default_timeformat_lambda(x)
-        )
+        self.timeformat_lambda = kwargs.pop("timeformat_lambda", self._default_timeformat_lambda)
         self._check_timeformat_lambda()
         super(BitbucketBase, self).__init__(url, *args, **kwargs)
 


### PR DESCRIPTION
The current **created_on** and **completed_on** field of pipeline state is like "2025-03-19T09:55:18.544325754Z" which can not be parsed by datetime.strptime directly
https://github.com/atlassian-api/atlassian-python-api/blob/c2f3382e27bd897b9dc29a3a4ebe1b6926aa84a4/atlassian/bitbucket/base.py#L168

