### PR TITLE
Fix 404 error when trying to download attachments from page, multiple hosts

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -1468,7 +1468,7 @@ class Confluence(AtlassianRestAPI):
             downloaded_files = {}
             for attachment in attachments:
                 file_name = attachment["title"] or attachment["id"]  # Use attachment ID if title is unavailable
-                download_link = self.url + attachment["_links"]["download"]
+                download_link = attachment["_links"]["download"]
                 # Fetch the file content
                 response = self.get(str(download_link), not_json_response=True)
 


### PR DESCRIPTION
Error 

`requests.exceptions.HTTPError: HTTP error occurred while downloading attachments: 404 Client Error: Not Found for url: https://pylaunch.atlassian.net/wiki/https://pylaunch.atlassian.net/wiki/download/attachments/`