### PR TITLE
Remove use of six

### DIFF
--- a/atlassian/bitbucket/cloud/repositories/deploymentEnvironments.py
+++ b/atlassian/bitbucket/cloud/repositories/deploymentEnvironments.py
@@ -2,7 +2,7 @@
 
 from ..base import BitbucketCloudBase
 
-from six.moves.urllib.parse import urlunsplit, urlsplit
+from urllib.parse import urlunsplit, urlsplit
 
 
 class DeploymentEnvironments(BitbucketCloudBase):

--- a/atlassian/request_utils.py
+++ b/atlassian/request_utils.py
@@ -1,39 +1,14 @@
 import logging
 
-from six import PY3
-
-
-# Additional log methods
-def logger_has_handlers(logger):
-    """Since Python 2 doesn't provide Logger.hasHandlers(), we have to
-    perform the lookup by ourselves."""
-
-    if PY3:
-        return logger.hasHandlers()
-    else:
-        c = logger
-        rv = False
-        while c:
-            if c.handlers:
-                rv = True
-                break
-            if not c.propagate:
-                break
-            else:
-                c = c.parent
-        return rv
-
 
 def get_default_logger(name):
     """Get a logger from default logging manager. If no handler
     is associated, add a default NullHandler"""
 
     logger = logging.getLogger(name)
-    if not logger_has_handlers(logger):
+    if not logger.hasHandlers():
         # If logging is not configured in the current project, configure
-        # this logger to discard all logs messages. This will prevent
-        # the 'No handlers could be found for logger XXX' error on Python 2,
-        # and avoid redirecting errors to the default 'lastResort'
-        # StreamHandler on Python 3
+        # this logger to discard all logs messages. This will  avoid
+        # redirecting errors to the default 'lastResort' StreamHandler
         logger.addHandler(logging.NullHandler())
     return logger

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
     overload,
 )
+from urllib.parse import urlencode
 
 import requests
 import urllib3
@@ -27,7 +28,6 @@ except ImportError:
 
 from requests import HTTPError, Response, Session
 from requests_oauthlib import OAuth1, OAuth2
-from six.moves.urllib.parse import urlencode
 from typing_extensions import Self
 from urllib3.util import Retry
 

--- a/examples/jira/jira_project_leaders.py
+++ b/examples/jira/jira_project_leaders.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 from atlassian import Jira
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,7 +330,7 @@ init-import = 'no'
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules = 'six.moves,past.builtins,future.builtins,builtins,io'
+redefining-builtins-modules = 'past.builtins,future.builtins,builtins,io'
 
 
 [tool.pylint.FORMAT]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ mypy>=0.812
 doc8
 types-Deprecated
 types-requests
-types-six
 types-beautifulsoup4
 types-jmespath
 types-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Deprecated
 requests>=2.8.1
-six
 oauthlib
 requests-oauthlib
 requests-kerberos==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_dir={"atlassian": "atlassian"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=["deprecated", "requests", "six", "oauthlib", "requests_oauthlib", "jmespath", "beautifulsoup4", "typing-extensions"],
+    install_requires=["deprecated", "requests", "oauthlib", "requests_oauthlib", "jmespath", "beautifulsoup4", "typing-extensions"],
     extras_require={"kerberos": ["requests-kerberos"]},
     platforms="Platform Independent",
     classifiers=[


### PR DESCRIPTION
Now that the minimum supported version of Python is 3.9, and Python 2 has been removed, also remove the use of six, since it isn't needed to maintain compatibility.