### PR TITLE
[Doc] [Jira] Update info about jira.get_issue_tree_recursive method

### DIFF
--- a/docs/jira.rst
+++ b/docs/jira.rst
@@ -395,8 +395,13 @@ Manage issues
     # Scrap regex matches from issue description and comments:
     jira.scrap_regex_from_issue(issue_key, regex)
 
-    # Get tree representation of issue and its subtasks + inward issue links
-    jira.get_issue_tree(issue_key)
+    # Get a list that contains the tree structure of the root issue, with all subtasks and inward linked issues.
+    # (!) Function only returns child issues from the same Jira instance or from an instance to which the API key has access.
+    # :param issue_key: Jira issue key
+    # :param tree: list to store the tree structure for recursion. Do not change it.
+    # :param depth: current depth of the tree for recursion. Do not change it.
+    # :return: list of dictionaries containing the tree structure. Dictionary element contains a key (parent issue) and value (child issue).
+    jira.get_issue_tree_recursive(issue_key, tree=[], depth=0)
 
 Epic Issues
 -------------


### PR DESCRIPTION
Found on [readthedocs](https://atlassian-python-api.readthedocs.io/jira.html) that the method _jira.get_issue_tree_ does not work. Use _get_issue_tree_recursive_ instead. In this regard, I decided to try updating the documentation. I suppose that the edit in the source will also correct the information on readthedocs. Is it right? 🤔