### PR TITLE
[Confluence] Sanitize attachment filenames to prevent download failures

### DIFF
--- a/atlassian/confluence/__init__.py
+++ b/atlassian/confluence/__init__.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+import warnings
 from typing import cast
 
 import requests
@@ -1569,6 +1570,15 @@ class Confluence(AtlassianRestAPI):
                     file_obj = io.BytesIO(response)
                     downloaded_files[file_name] = file_obj
                 else:
+                    # Sanitize filename if needed
+                    if re.search(r'[<>:"/\\|?*\x00-\x1F]', file_name):
+                        sanitized = re.sub(r'[<>:"/\\|?*\x00-\x1F]', '_', file_name)
+                        warnings.warn(
+                            f"File name '{file_name}' contained invalid characters and was renamed to '{sanitized}'.",
+                            UserWarning
+                        )
+                        file_name = sanitized
+                    file_path = os.path.join(path, file_name)
                     # Save file to disk
                     file_path = os.path.join(path, file_name)
                     with open(file_path, "wb") as file:


### PR DESCRIPTION
### Pull Request Description

This PR improves the `download_attachments_from_page` method by adding filename sanitization to handle invalid characters in attachment filenames that can cause download failures on certain file systems.

While building a component for Confluence and scraping one of the spaces, I noticed that some files could not be downloaded because their names contained invalid characters (such as `<>:"/\|?*` and control characters) which are not allowed on Windows and other platforms.

To address this, the code now replaces these invalid characters with underscores (`_`) to ensure files can be saved without errors. Additionally, a warning is issued to notify users when a filename has been modified due to sanitization.

As an example, when running on macOS, I encountered a filename like:

```
image2017-9-24 20:1:28.png
```

which, after sanitization for Windows compatibility, would be handled gracefully by the refactored code. The refactor aims to be general and platform-agnostic, but focused on preventing errors commonly seen on Windows.

This is my first pull request to a major open-source library, so I welcome any comments, suggestions, or recommendations for improving the implementation or code style. I’m happy to make any necessary adjustments to meet the project’s standards.

Thanks for reading.
