### PR TITLE
Update license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name="atlassian-python-api",
     description="Python Atlassian REST API Wrapper",
     long_description=long_description,
-    license="Apache License 2.0",
+    license="Apache-2.0",
     version=version,
     download_url="https://github.com/atlassian-api/atlassian-python-api",
     author="Matt Harasymczuk",


### PR DESCRIPTION
The `license_expression` for the [PyPI API response](https://pypi.org/pypi/atlassian-python-api/json) is `null` because `Apache License 2.0` is not a [valid SPDX identifier](https://spdx.org/licenses/). This PR fixes that :)

[PEP-639 has additional context and info](https://peps.python.org/pep-0639/#project-source-metadata) if that is helpful. Appreciate you taking the time to consider my PR!