### PR TITLE
Make using session the default

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -78,7 +78,7 @@ class AtlassianRestAPI(object):
         api_root: str = "rest/api",
         api_version: Union[str, int] = "latest",
         verify_ssl: bool = True,
-        session: Optional[requests.Session] = None,
+        session: Optional[requests.Session] = requests.Session(),
         oauth: Optional[dict] = None,
         oauth2: Optional[dict] = None,
         cookies: Optional[CookieJar] = None,


### PR DESCRIPTION
I have no idea why you would not want to use a session by default. If you make more than 1 request in your script you benefit by an order of magnitude on wait to reconnect.