### PR TITLE
Update jira.py

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -3701,7 +3701,7 @@ class Jira(AtlassianRestAPI):
             params["expand"] = expand
         if validate_query is not None:
             params["validateQuery"] = validate_query
-        if self.cloud:
+        if not self.cloud:
             url = self.resource_url("search")
         else:
             url = self.resource_url("search/jql")


### PR DESCRIPTION
Jira cloud has deprecated the `/search?jql` endpoint in favor of `/search/jql?jql=`

I think that the condition is wrong