### PR TITLE
Jira: Add handling for errorMessages field in JSM responses

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -921,7 +921,10 @@ class ServiceDesk(AtlassianRestAPI):
         if 400 <= response.status_code < 600:
             try:
                 j = response.json()
-                error_msg = j["errorMessage"]
+                if "errorMessage" in j:
+                    error_msg = j["errorMessage"]
+                elif "errorMessages" in j:
+                    error_msg = ", ".join(j["errorMessages"] or [])
             except Exception as e:
                 log.error(e)
                 response.raise_for_status()


### PR DESCRIPTION
We are occasionally receiving errors from JSM requests like this:

```json
{
  errorMessages: [
    "Field Assignee is required."
  ],
  errors: {}
}
```

This results in a `KeyError: 'errorMessage'` exception.