### PR TITLE
feat(Service Desk): Add endpoints for specific request type data and itd fields

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -182,6 +182,26 @@ class ServiceDesk(AtlassianRestAPI):
             f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype/{request_type_id}",
             headers=self.experimental_headers,
         )
+
+    def get_request_type_fields(self, service_desk_id, request_type_id):
+        """
+        Retrieve the fields for a specific request type in a service desk.
+
+        :param service_desk_id: The ID of the service desk for which the request type
+            fields are to be retrieved.
+        :type service_desk_id: str
+        :param request_type_id: The ID of the request type within the specified service
+            desk.
+        :type request_type_id: str
+        :return: A response object containing the fields information for the specified
+            request type.
+        :rtype: requests.Response
+        """
+
+        return self.get(
+            f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype/{request_type_id}/field",
+            headers=self.experimental_headers,
+        )
         
     # Participants actions
     def get_request_participants(self, issue_id_or_key, start=0, limit=50):

--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -166,7 +166,23 @@ class ServiceDesk(AtlassianRestAPI):
             f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype",
             headers=self.experimental_headers,
         )
+    def get_request_type(self, service_desk_id, request_type_id):
+        """
+        Fetches detailed information about a specific request type within a service desk.
 
+        :param service_desk_id: The ID of the service desk where the request type
+            exists.
+        :type service_desk_id: str
+        :param request_type_id: The ID of the request type to retrieve.
+        :type request_type_id: str
+        :return: A dictionary containing the details of the specified request type.
+        :rtype: dict
+        """
+        return self.get(
+            f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype/{request_type_id}",
+            headers=self.experimental_headers,
+        )
+        
     # Participants actions
     def get_request_participants(self, issue_id_or_key, start=0, limit=50):
         """

--- a/docs/service_desk.rst
+++ b/docs/service_desk.rst
@@ -66,8 +66,24 @@ Manage a Participants
     # The calling user must have permission to manage participants for this customer request
     sd.remove_request_participants(issue_id_or_key, users_list=None, account_list=None)
 
+
+Request types
+---------------------
+
+.. code-block:: python
+
+    # Get all request types in a serrvice desk project
+    sd.get_request_types(service_desk_id)
+
+    # Get single request type in a given serrvice desk project
+    sd.get_request_type(service_desk_id, request_type_id)
+
+    # Get field composition of a given request type
+    sd.get_request_type_fields(service_desk_id, request_type_id)
+
+
 Transitions
------------
+---------------------
 
 **EXPERIMENTAL** (may change without notice)
 


### PR DESCRIPTION
This PR adds two new methods to the Service Desk project to allow fetching specific request type information, avoiding the need to retrieve the entire collection.

- get_request_type: Fetches a single request type by its ID.
- get_request_type_fields: Fetches the field composition for a specific request type.