### PR TITLE
[service-desk] Fix whitespace issue causing black to fail

### DIFF
--- a/atlassian/service_desk.py
+++ b/atlassian/service_desk.py
@@ -166,6 +166,7 @@ class ServiceDesk(AtlassianRestAPI):
             f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype",
             headers=self.experimental_headers,
         )
+
     def get_request_type(self, service_desk_id, request_type_id):
         """
         Fetches detailed information about a specific request type within a service desk.


### PR DESCRIPTION
I was developing another feature, but upon running `make docker-qa`, I was getting a `black` failure on service_desk.py. I thought I'd fix that so that future builds would pass.