### PR TITLE
test: ensure page exists before attaching files

### DIFF
--- a/tests/test_confluence_attach.py
+++ b/tests/test_confluence_attach.py
@@ -42,7 +42,9 @@ class TestConfluenceAttach(unittest.TestCase):
         space = "SAN"
         title = "atlassian-python-rest-api-wrapper"
 
-        # TODO: check if page are exists
+        # check if page exists, create if not
+        if not confluence.page_exists(space, title):
+            confluence.create_page(space, title, "Initial content for testing")
 
         fd, filename = tempfile.mkstemp("w")
         os.write(fd, b"Hello World - Version 1")
@@ -87,7 +89,9 @@ class TestConfluenceAttach(unittest.TestCase):
         space = "SAN"
         title = "atlassian-python-rest-api-wrapper"
 
-        # TODO: check if page are exists
+        # check if page exists, create if not
+        if not confluence.page_exists(space, title):
+            confluence.create_page(space, title, "Initial content for testing")
 
         fd, filename = tempfile.mkstemp("w")
         os.write(fd, b"Hello World - Version 1")


### PR DESCRIPTION
Resolved TODOs i
     test_confluence_attach.py by adding logic to verify and create test pages before performing fil
     attachments.