### PR TITLE
[Rest] Clamp non-finite Retry-After values

### DIFF
--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -2,6 +2,7 @@
 
 import logging
 import random
+import math
 import time
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -323,6 +324,10 @@ class AtlassianRestAPI(object):
 
         if delay_seconds is None:
             return None
+
+        if not math.isfinite(delay_seconds):
+            log.debug("Retry-After value is not finite; clamping to max_backoff_seconds")
+            delay_seconds = float(self.max_backoff_seconds)
 
         delay_seconds = max(0.0, delay_seconds)
         if delay_seconds > self.max_backoff_seconds:

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -395,6 +395,27 @@ class TestAtlassianRestAPI:
         assert handler(response) is True
         assert captured["delay"] == 5
 
+    def test_retry_handler_clamps_non_finite_retry_after(self, monkeypatch):
+        """Ensure non-finite Retry-After headers are clamped to max_backoff_seconds."""
+        captured = {}
+
+        def fake_sleep(delay):
+            captured["delay"] = delay
+
+        monkeypatch.setattr("atlassian.rest_client.time.sleep", fake_sleep)
+
+        api = AtlassianRestAPI(
+            url=f"{mockup_server()}/test",
+            retry_with_header=True,
+            max_backoff_seconds=7,
+        )
+
+        handler = api._retry_handler()
+        response = SimpleNamespace(headers={"Retry-After": "1e309"}, status_code=429)
+
+        assert handler(response) is True
+        assert captured["delay"] == 7
+
     def test_retry_handler_parses_http_date(self, monkeypatch):
         """Ensure HTTP-date Retry-After headers are converted to delta seconds."""
         captured = {}


### PR DESCRIPTION
  ## Summary
  - Add unit test for non-finite Retry-After handling.
  - Clamp non-finite Retry-After values (e.g., `1e309` → `inf`) to `max_backoff_seconds`.

  ## What Goes Wrong Today
  - The library parses `Retry-After` as a number.
  - Extremely large values can become `inf`, which can break or cause unrealistic sleep behavior.

  ## What The Fix Does
  - After parsing, checks whether the value is finite.
  - If not finite, clamps it to `max_backoff_seconds`.
  - Uses the safe value for `time.sleep`.

  ## Why This Is Safe
  - The library already clamps large finite values to `max_backoff_seconds`.
  - `inf` is just “beyond large”; clamping keeps behavior consistent.
  - Preserves intended semantics: wait, but not forever.

  ## Tests
  - pytest -q tests/test_rest_client.py -k "retry_handler"