### PR TITLE
Run black formatter - update: which version to use?

### DIFF
--- a/atlassian/__init__.py
+++ b/atlassian/__init__.py
@@ -19,7 +19,6 @@ from .service_desk import ServiceDesk as ServiceManagement
 from .tempo import TempoCloud, TempoServer
 from .xray import Xray
 
-
 __all__ = [
     "Confluence",
     "ConfluenceCloud",

--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -62,7 +62,17 @@ class Bamboo(AtlassianRestAPI):
             logging.error(f"Broken response: {response}")
             yield response
 
-    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, label=None, start_index=0, **kwargs):  # fmt: skip
+    def base_list_call(
+        self,
+        resource,
+        expand,
+        favourite,
+        clover_enabled,
+        max_results,
+        label=None,
+        start_index=0,
+        **kwargs,
+    ):
         flags = []
         params = {"max-results": max_results}
         if expand:
@@ -612,7 +622,14 @@ class Bamboo(AtlassianRestAPI):
         params = {"buildKey": plan_key, "buildNumber": build_number}
         return self.post(custom_resource, params=params, headers=self.form_token_headers)
 
-    def execute_build(self, plan_key, stage=None, execute_all_stages=True, custom_revision=None, **bamboo_variables):  # fmt: skip
+    def execute_build(
+        self,
+        plan_key,
+        stage=None,
+        execute_all_stages=True,
+        custom_revision=None,
+        **bamboo_variables,
+    ):
         """
         Fire build execution for specified plan.
         !IMPORTANT! NOTE: for some reason, this method always execute all stages

--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -62,17 +62,7 @@ class Bamboo(AtlassianRestAPI):
             logging.error(f"Broken response: {response}")
             yield response
 
-    def base_list_call(
-        self,
-        resource,
-        expand,
-        favourite,
-        clover_enabled,
-        max_results,
-        label=None,
-        start_index=0,
-        **kwargs
-    ):  # fmt: skip
+    def base_list_call(self, resource, expand, favourite, clover_enabled, max_results, label=None, start_index=0, **kwargs):  # fmt: skip
         flags = []
         params = {"max-results": max_results}
         if expand:
@@ -622,14 +612,7 @@ class Bamboo(AtlassianRestAPI):
         params = {"buildKey": plan_key, "buildNumber": build_number}
         return self.post(custom_resource, params=params, headers=self.form_token_headers)
 
-    def execute_build(
-        self,
-        plan_key,
-        stage=None,
-        execute_all_stages=True,
-        custom_revision=None,
-        **bamboo_variables
-    ):  # fmt: skip
+    def execute_build(self, plan_key, stage=None, execute_all_stages=True, custom_revision=None, **bamboo_variables):  # fmt: skip
         """
         Fire build execution for specified plan.
         !IMPORTANT! NOTE: for some reason, this method always execute all stages

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2568,15 +2568,7 @@ class Bitbucket(BitbucketBase):
         url = self._url_code_insights_report(project_key, repository_slug, commit_id, report_key)
         return self.delete(url)
 
-    def create_code_insights_report(
-        self,
-        project_key,
-        repository_slug,
-        commit_id,
-        report_key,
-        report_title,
-        **report_params
-    ):  # fmt: skip
+    def create_code_insights_report(self, project_key, repository_slug, commit_id, report_key, report_title, **report_params):  # fmt: skip
         """
         Create a new insight report, or replace the existing one
         if a report already exists for the given repository_slug, commit, and report key.

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -2568,7 +2568,15 @@ class Bitbucket(BitbucketBase):
         url = self._url_code_insights_report(project_key, repository_slug, commit_id, report_key)
         return self.delete(url)
 
-    def create_code_insights_report(self, project_key, repository_slug, commit_id, report_key, report_title, **report_params):  # fmt: skip
+    def create_code_insights_report(
+        self,
+        project_key,
+        repository_slug,
+        commit_id,
+        report_key,
+        report_title,
+        **report_params,
+    ):
         """
         Create a new insight report, or replace the existing one
         if a report already exists for the given repository_slug, commit, and report key.

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -359,7 +359,12 @@ class AtlassianRestAPI(object):
                 delay = self._parse_retry_after_header(response.headers.get("Retry-After"))
                 if delay is not None:
                     retry_with_header_count += 1
-                    log.debug("Retrying after %s seconds (attempt %d/%d)", delay, retry_with_header_count, max_retry_with_header_attempts)
+                    log.debug(
+                        "Retrying after %s seconds (attempt %d/%d)",
+                        delay,
+                        retry_with_header_count,
+                        max_retry_with_header_attempts,
+                    )
                     time.sleep(delay)
                     return True
 

--- a/atlassian/statuspage.py
+++ b/atlassian/statuspage.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 """Statuspage API wrapper."""
+
 import logging
 from enum import Enum
 

--- a/atlassian/utils.py
+++ b/atlassian/utils.py
@@ -213,14 +213,12 @@ def block_code_macro_confluence(code, lang=None):
     """
     if not lang:
         lang = ""
-    return (
-        """\
+    return ("""\
                 <ac:structured-macro ac:name="code" ac:schema-version="1">
                     <ac:parameter ac:name="language">{lang}</ac:parameter>
                     <ac:plain-text-body><![CDATA[{code}]]></ac:plain-text-body>
                 </ac:structured-macro>
-            """
-    ).format(lang=lang, code=code)
+            """).format(lang=lang, code=code)
 
 
 def html_code__macro_confluence(text):
@@ -229,13 +227,11 @@ def html_code__macro_confluence(text):
     :param text:
     :return:
     """
-    return (
-        """\
+    return ("""\
                 <ac:structured-macro ac:name="html" ac:schema-version="1">
                     <ac:plain-text-body><![CDATA[{text}]]></ac:plain-text-body>
                 </ac:structured-macro>
-            """
-    ).format(text=text)
+            """).format(text=text)
 
 
 def noformat_code_macro_confluence(text, nopanel=None):
@@ -247,14 +243,12 @@ def noformat_code_macro_confluence(text, nopanel=None):
     """
     if not nopanel:
         nopanel = False
-    return (
-        """\
+    return ("""\
                 <ac:structured-macro ac:name="noformat" ac:schema-version="1">
                     <ac:parameter ac:name="nopanel">{nopanel}</ac:parameter>
                     <ac:plain-text-body><![CDATA[{text}]]></ac:plain-text-body>
                 </ac:structured-macro>
-            """
-    ).format(nopanel=nopanel, text=text)
+            """).format(nopanel=nopanel, text=text)
 
 
 def symbol_normalizer(text):

--- a/examples/confluence/confluence_attach_file.py
+++ b/examples/confluence/confluence_attach_file.py
@@ -3,6 +3,7 @@
 This is example to attach file with mimetype
 
 """
+
 import logging
 
 # https://pypi.org/project/python-magic/

--- a/examples/confluence/confluence_scrap_regex_from_page.py
+++ b/examples/confluence/confluence_scrap_regex_from_page.py
@@ -1,6 +1,5 @@
 from atlassian import Confluence
 
-
 confluence = Confluence(
     url="<instance_url>",
     username="<user_enamil>",

--- a/examples/jira/jira_admins_confluence_page.py
+++ b/examples/jira/jira_admins_confluence_page.py
@@ -12,15 +12,13 @@ jira = Jira(url="http://localhost:8080", username="admin", password="admin")
 
 confluence = Confluence(url="http://localhost:8090", username="admin", password="admin")
 
-html = [
-    """<table>
+html = ["""<table>
                 <tr>
                     <th>Project Key</th>
                     <th>Project Name</th>
                     <th>Leader</th>
                     <th>Email</th>
-                </tr>"""
-]
+                </tr>"""]
 
 for data in jira.project_leaders():
     log.info("{project_key} leader is {lead_name} <{lead_email}>".format(**data))

--- a/examples/jira/jira_project_administrators.py
+++ b/examples/jira/jira_project_administrators.py
@@ -17,9 +17,7 @@ for data in jira.project_leaders():
                     <td>{project_name}</td>
                     <td>{lead_name}</td>
                     <td><a href="mailto:{lead_email}">{lead_email}</a></td>
-                </tr>""".format(
-        **data
-    )
+                </tr>""".format(**data)
 
 html += "</table>"
 

--- a/examples/jira/jira_project_leaders.py
+++ b/examples/jira/jira_project_leaders.py
@@ -7,8 +7,7 @@ from atlassian import Jira
 jira = Jira(url="http://localhost:8080", username="admin", password="admin")
 
 EMAIL_SUBJECT = quote("Jira access to project {project_key}")
-EMAIL_BODY = quote(
-    """I am asking for access to the {project_key} project in Jira.
+EMAIL_BODY = quote("""I am asking for access to the {project_key} project in Jira.
 
 To give me the appropriate permissions, assign me to a role on the page:
 http://localhost:8080/plugins/servlet/project-config/{project_key}/roles
@@ -16,8 +15,7 @@ http://localhost:8080/plugins/servlet/project-config/{project_key}/roles
 Role:
 Users - read-only access + commenting
 Developers - work on tasks, editing, etc.
-Admin - Change of configuration and the possibility of starting sprints"""
-)
+Admin - Change of configuration and the possibility of starting sprints""")
 
 MAILTO = '<a href="mailto:{lead_email}?subject={email_subject}&body={email_body}">{lead_name}</a>'
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,5 +1,6 @@
 # coding: utf8
 """Tests for Jira Modules"""
+
 from unittest import TestCase
 from atlassian import jira
 from .mockup import mockup_server

--- a/tests/test_rest_client.py
+++ b/tests/test_rest_client.py
@@ -421,6 +421,7 @@ class TestAtlassianRestAPI:
 
     def test_retry_handler_skips_invalid_header(self, monkeypatch):
         """Ensure invalid Retry-After headers fall back to regular logic."""
+
         def fake_sleep(_):
             raise AssertionError("sleep should not be called for invalid header")
 


### PR DESCRIPTION
Checks were failing because of black formatter found unformatted code from previous commits and PRs.

~~I have run `black .` to format the whole repository.~~

~~Also, It appears that `# fmt: skip` does not work with multi-line method signatures.~~
~~The issue was fixed to preserve multi-line signature by removing `# fmt: skip` comment and by adding trailing comma for the last parameter.~~

~~black, 26.3.0 (compiled: yes)~~
~~Python (CPython) 3.11.11~~


**update**

It appears that the checks are failed because the latest version of black `black==26.3.0` does not support Python 3.9.

I suppose we have two ways of handling this.

- One is to drop the Python 3.9 support, because it reached end of life on October 2025.

- Other is to set the black version in `requirements-dev.txt` file to `black==25.11.0`.

Which would be the better option?