### PR TITLE
Run black formatter - outdated version for Python 3.9

### DIFF
--- a/atlassian/confluence/__init__.py
+++ b/atlassian/confluence/__init__.py
@@ -25,9 +25,12 @@ class Confluence(ConfluenceBase):
         if is_cloud is None:
             hostname = urlparse(url).hostname or ""
             is_cloud = (
-                hostname == "atlassian.net" or hostname.endswith(".atlassian.net")
-                or hostname == "jira.com" or hostname.endswith(".jira.com")
-                or hostname == "api.atlassian.com" or hostname.endswith(".api.atlassian.com")
+                hostname == "atlassian.net"
+                or hostname.endswith(".atlassian.net")
+                or hostname == "jira.com"
+                or hostname.endswith(".jira.com")
+                or hostname == "api.atlassian.com"
+                or hostname.endswith(".api.atlassian.com")
             )
         if is_cloud:
             impl = ConfluenceCloud(url, *args, **kwargs)

--- a/atlassian/confluence/cloud/base.py
+++ b/atlassian/confluence/cloud/base.py
@@ -23,5 +23,3 @@ class ConfluenceCloudBase(ConfluenceBase):
         :return: nothing
         """
         super(ConfluenceCloudBase, self).__init__(url, *args, **kwargs)
-
-

--- a/atlassian/confluence/server/__init__.py
+++ b/atlassian/confluence/server/__init__.py
@@ -297,7 +297,9 @@ class Server(ConfluenceServerBase):
 
     def get_all_draft_blog_posts_from_space(self, space_key, **kwargs):
         """Get all draft blog posts from space."""
-        return self._get_paged("content", params={"spaceKey": space_key, "type": "blogpost", "status": "draft", **kwargs})
+        return self._get_paged(
+            "content", params={"spaceKey": space_key, "type": "blogpost", "status": "draft", **kwargs}
+        )
 
     # Trash Management
     def get_trash_content(self, space_key, **kwargs):
@@ -310,7 +312,9 @@ class Server(ConfluenceServerBase):
 
     def get_all_blog_posts_from_space_trash(self, space_key, **kwargs):
         """Get all blog posts from space trash."""
-        return self._get_paged("content", params={"spaceKey": space_key, "type": "blogpost", "status": "trashed", **kwargs})
+        return self._get_paged(
+            "content", params={"spaceKey": space_key, "type": "blogpost", "status": "trashed", **kwargs}
+        )
 
     # Export
     def export_content(self, content_id, **kwargs):

--- a/atlassian/confluence/server/base.py
+++ b/atlassian/confluence/server/base.py
@@ -23,5 +23,3 @@ class ConfluenceServerBase(ConfluenceBase):
         :return: nothing
         """
         super(ConfluenceServerBase, self).__init__(url, *args, **kwargs)
-
-

--- a/tests/confluence/test_confluence_cloud.py
+++ b/tests/confluence/test_confluence_cloud.py
@@ -579,7 +579,7 @@ class TestConfluenceCloud:
         assert result == [{"id": "1", "title": "Page 1"}, {"id": "2", "title": "Page 2"}]
 
         assert mock_get.call_count == 2
-        
+
         # Verify the second call used scheme+host from self.url (preserving API gateway routing)
         args, kwargs = mock_get.call_args_list[1]
         assert args[0] == "https://test.atlassian.net/rest/api/content?cursor=1"

--- a/tests/confluence/test_confluence_routing.py
+++ b/tests/confluence/test_confluence_routing.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 """Tests for legacy Confluence class URL routing."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+# from unittest.mock import MagicMock
 
-import pytest
+# import pytest
 
 from atlassian.confluence import Confluence, ConfluenceCloud, ConfluenceServer
 

--- a/tests/confluence/test_confluence_routing.py
+++ b/tests/confluence/test_confluence_routing.py
@@ -2,6 +2,7 @@
 """Tests for legacy Confluence class URL routing."""
 
 from unittest.mock import patch
+
 # from unittest.mock import MagicMock
 
 # import pytest


### PR DESCRIPTION
Recent merges had checks failing again.

I have run the black formatter, and also commented out unused import to have flake8 pass.

As pointed out in #1619, latest version of `black==26.3.1` does not support Python 3.9.

We have two options that I can think of.

- One is to drop the Python 3.9 support, because it reached end of life on October 2025.

- Other is to set the black version in `requirements-dev.txt` file to `black==25.11.0`.

This PR only runs formatter, and does not implement the solutions above.