### PR TITLE
Fix add_comment_to_object using params instead of data

### DIFF
--- a/atlassian/assets.py
+++ b/atlassian/assets.py
@@ -174,7 +174,7 @@ class AssetsCloud(AtlassianRestAPI):
             raise NotImplementedError
         params = {"comment": comment, "objectId": object_id, "role": role}
         url = "rest/assets/1.0/comment/create"
-        return self.post(url, params=params)
+        return self.post(url, data=params)
 
     def get_comment_of_object(self, object_id):
         """

--- a/atlassian/insight.py
+++ b/atlassian/insight.py
@@ -173,7 +173,7 @@ class Insight(AtlassianRestAPI):
             raise NotImplementedError
         params = {"comment": comment, "objectId": object_id, "role": role}
         url = "rest/insight/1.0/comment/create"
-        return self.post(url, params=params)
+        return self.post(url, data=params)
 
     def get_comment_of_object(self, object_id):
         """


### PR DESCRIPTION
## Summary
- `add_comment_to_object` in both `insight.py` and `assets.py` was sending the comment payload as query string parameters (`params=`) instead of a JSON request body (`data=`), causing a 500 error from the server.

Closes #1596