### PR TITLE
Add page_exists and blog_post_exists to Confluence Cloud

### DIFF
--- a/atlassian/confluence/cloud/__init__.py
+++ b/atlassian/confluence/cloud/__init__.py
@@ -60,6 +60,24 @@ class Cloud(ConfluenceCloudBase):
         """Get ancestor content."""
         return self.get(f"content/{content_id}/ancestors", **kwargs)
 
+    def get_page_by_title(self, space_key, title, **kwargs):
+        """Get page by title and space key."""
+        return self.get("content", params={"spaceKey": space_key, "title": title, "type": "page", **kwargs})
+
+    def get_blog_post_by_title(self, space_key, title, **kwargs):
+        """Get blog post by title and space key."""
+        return self.get("content", params={"spaceKey": space_key, "title": title, "type": "blogpost", **kwargs})
+
+    def page_exists(self, space_key, title, **kwargs):
+        """Check if page exists."""
+        result = self.get_page_by_title(space_key, title, **kwargs)
+        return len(result.get("results", [])) > 0
+
+    def blog_post_exists(self, space_key, title, **kwargs):
+        """Check if blog post exists."""
+        result = self.get_blog_post_by_title(space_key, title, **kwargs)
+        return len(result.get("results", [])) > 0
+
     # Space Management
     def get_spaces(self, **kwargs):
         """Get all spaces."""


### PR DESCRIPTION
## Summary
- Add `get_page_by_title()`, `get_blog_post_by_title()`, `page_exists()`, and `blog_post_exists()` to the Confluence Cloud module
- These methods already existed in the Server module but were missing from Cloud, creating an API parity gap

Closes #581