### PR TITLE
Fix Jira reindex methods and implement reindex_issue

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -4614,7 +4614,7 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
             params["indexChangeHistory"] = change_history
         if not worklogs:
             params["indexWorklogs"] = worklogs
-        if not indexing_type:
+        if indexing_type:
             params["type"] = indexing_type
         url = self.resource_url("reindex")
         return self.post(url, params=params)
@@ -4642,7 +4642,8 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
         :return:
         """
         url = self.resource_url("reindex")
-        return self.get(url)
+        response = self.request("GET", path=url, allow_redirects=False)
+        return response.json()
 
     def reindex_project(self, project_key: str) -> T_resp_json:
         return self.post(
@@ -4651,8 +4652,15 @@ api-group-workflows/#api-rest-api-2-workflow-search-get)
             headers=self.form_token_headers,
         )
 
-    def reindex_issue(self, list_of_: list) -> None:
-        pass
+    def reindex_issue(self, issue_ids: list) -> T_resp_json:
+        """
+        Reindex specific issues by their IDs.
+        :param issue_ids: list of issue IDs (numeric) to reindex
+        :return:
+        """
+        url = self.resource_url("reindex/issue")
+        params = {"issueId": ",".join(str(i) for i in issue_ids)}
+        return self.post(url, params=params)
 
     def index_checker(self, max_results: int = 100) -> T_resp_json:
         """

--- a/atlassian/rest_client.py
+++ b/atlassian/rest_client.py
@@ -439,6 +439,7 @@ class AtlassianRestAPI(object):
         trailing: Optional[bool] = None,
         absolute: bool = False,
         advanced_mode: bool = False,
+        allow_redirects: bool = True,
     ) -> Response:
         """
 
@@ -492,6 +493,7 @@ class AtlassianRestAPI(object):
                 files=files,
                 proxies=self.proxies,
                 cert=self.cert,
+                allow_redirects=allow_redirects,
             )
             continue_retries = retry_handler(response)
             if continue_retries:


### PR DESCRIPTION
## Summary
- **`reindex()` / `reindex_with_type()`**: The `indexing_type` parameter was never sent to the API — `if not indexing_type` was always `False` since it defaults to `"BACKGROUND_PREFERRED"`. Changed to `if indexing_type`.
- **`reindex_status()`**: Jira 10+ returns HTTP 303 during an active reindex, causing `TooManyRedirects`. Now uses `allow_redirects=False` to get the response directly.
- **`reindex_issue()`**: Was a stub (`pass`). Now calls `POST /rest/api/2/reindex/issue` with the given issue IDs.
- Added `allow_redirects` parameter to `rest_client.request()` for callers that need to opt out of redirect following.

Closes #1610