### PR TITLE
Add get_child_pages and get_descendant_pages to Confluence

### DIFF
--- a/atlassian/confluence/__init__.py
+++ b/atlassian/confluence/__init__.py
@@ -25,9 +25,12 @@ class Confluence(ConfluenceBase):
         if is_cloud is None:
             hostname = urlparse(url).hostname or ""
             is_cloud = (
-                hostname == "atlassian.net" or hostname.endswith(".atlassian.net")
-                or hostname == "jira.com" or hostname.endswith(".jira.com")
-                or hostname == "api.atlassian.com" or hostname.endswith(".api.atlassian.com")
+                hostname == "atlassian.net"
+                or hostname.endswith(".atlassian.net")
+                or hostname == "jira.com"
+                or hostname.endswith(".jira.com")
+                or hostname == "api.atlassian.com"
+                or hostname.endswith(".api.atlassian.com")
             )
         if is_cloud:
             impl = ConfluenceCloud(url, *args, **kwargs)

--- a/atlassian/confluence/cloud/__init__.py
+++ b/atlassian/confluence/cloud/__init__.py
@@ -56,6 +56,14 @@ class Cloud(ConfluenceCloudBase):
         """Get descendant content."""
         return self.get(f"content/{content_id}/descendants", **kwargs)
 
+    def get_child_pages(self, content_id, **kwargs):
+        """Get child pages of a content item."""
+        return self.get(f"content/{content_id}/child/page", **kwargs)
+
+    def get_descendant_pages(self, content_id, **kwargs):
+        """Get all descendant pages of a content item."""
+        return self.get(f"content/{content_id}/descendant/page", **kwargs)
+
     def get_content_ancestors(self, content_id, **kwargs):
         """Get ancestor content."""
         return self.get(f"content/{content_id}/ancestors", **kwargs)

--- a/atlassian/confluence/cloud/base.py
+++ b/atlassian/confluence/cloud/base.py
@@ -23,5 +23,3 @@ class ConfluenceCloudBase(ConfluenceBase):
         :return: nothing
         """
         super(ConfluenceCloudBase, self).__init__(url, *args, **kwargs)
-
-

--- a/atlassian/confluence/server/__init__.py
+++ b/atlassian/confluence/server/__init__.py
@@ -48,6 +48,14 @@ class Server(ConfluenceServerBase):
         """Get descendant content."""
         return self.get(f"content/{content_id}/descendant", **kwargs)
 
+    def get_child_pages(self, content_id, **kwargs):
+        """Get child pages of a content item."""
+        return self.get(f"content/{content_id}/child/page", **kwargs)
+
+    def get_descendant_pages(self, content_id, **kwargs):
+        """Get all descendant pages of a content item."""
+        return self.get(f"content/{content_id}/descendant/page", **kwargs)
+
     def get_content_ancestors(self, content_id, **kwargs):
         """Get ancestor content."""
         return self.get(f"content/{content_id}/ancestor", **kwargs)
@@ -297,7 +305,9 @@ class Server(ConfluenceServerBase):
 
     def get_all_draft_blog_posts_from_space(self, space_key, **kwargs):
         """Get all draft blog posts from space."""
-        return self._get_paged("content", params={"spaceKey": space_key, "type": "blogpost", "status": "draft", **kwargs})
+        return self._get_paged(
+            "content", params={"spaceKey": space_key, "type": "blogpost", "status": "draft", **kwargs}
+        )
 
     # Trash Management
     def get_trash_content(self, space_key, **kwargs):
@@ -310,7 +320,9 @@ class Server(ConfluenceServerBase):
 
     def get_all_blog_posts_from_space_trash(self, space_key, **kwargs):
         """Get all blog posts from space trash."""
-        return self._get_paged("content", params={"spaceKey": space_key, "type": "blogpost", "status": "trashed", **kwargs})
+        return self._get_paged(
+            "content", params={"spaceKey": space_key, "type": "blogpost", "status": "trashed", **kwargs}
+        )
 
     # Export
     def export_content(self, content_id, **kwargs):

--- a/atlassian/confluence/server/base.py
+++ b/atlassian/confluence/server/base.py
@@ -23,5 +23,3 @@ class ConfluenceServerBase(ConfluenceBase):
         :return: nothing
         """
         super(ConfluenceServerBase, self).__init__(url, *args, **kwargs)
-
-

--- a/tests/confluence/test_confluence_cloud.py
+++ b/tests/confluence/test_confluence_cloud.py
@@ -579,7 +579,7 @@ class TestConfluenceCloud:
         assert result == [{"id": "1", "title": "Page 1"}, {"id": "2", "title": "Page 2"}]
 
         assert mock_get.call_count == 2
-        
+
         # Verify the second call used scheme+host from self.url (preserving API gateway routing)
         args, kwargs = mock_get.call_args_list[1]
         assert args[0] == "https://test.atlassian.net/rest/api/content?cursor=1"

--- a/tests/confluence/test_confluence_routing.py
+++ b/tests/confluence/test_confluence_routing.py
@@ -1,9 +1,7 @@
 # coding=utf-8
 """Tests for legacy Confluence class URL routing."""
 
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import patch
 
 from atlassian.confluence import Confluence, ConfluenceCloud, ConfluenceServer
 


### PR DESCRIPTION
## Summary
- Add `get_child_pages(content_id)` and `get_descendant_pages(content_id)` to both Confluence Cloud and Server modules
- Uses the `/child/page` and `/descendant/page` REST API endpoints which return only page children, unlike the existing `get_content_children`/`get_content_descendants` that return all content types (comments, attachments, etc.)
- Enables listing page tree/hierarchy for a space by starting from the space homepage

Closes #1613