### PR TITLE
[Confluence] Add get_all_spaces and switch Cloud space methods to v2 plural endpoint

### DIFF
--- a/atlassian/confluence/cloud/__init__.py
+++ b/atlassian/confluence/cloud/__init__.py
@@ -70,28 +70,43 @@ class Cloud(ConfluenceCloudBase):
 
     # Space Management
     def get_spaces(self, **kwargs):
-        """Get all spaces."""
-        return self.get("space", **kwargs)
+        """Get all spaces (single page).
+
+        Calls the Confluence Cloud v2 endpoint ``/wiki/api/v2/spaces``.
+        For paginated enumeration of every space, use :meth:`get_all_spaces`.
+        """
+        return self.get("spaces", **kwargs)
+
+    def get_all_spaces(self, **kwargs):
+        """Get all spaces with full pagination.
+
+        Returns a generator yielding each space dict from the Confluence Cloud
+        v2 endpoint ``/wiki/api/v2/spaces``. Replaces the legacy v1
+        ``get_all_spaces`` (which hit ``/rest/api/space``) — that endpoint is
+        not available on the OAuth API gateway and returns
+        ``GoneException: This deprecated endpoint has been removed``.
+        """
+        return self._get_paged("spaces", params=kwargs)
 
     def get_space(self, space_id, **kwargs):
         """Get space by ID."""
-        return self.get(f"space/{space_id}", **kwargs)
+        return self.get(f"spaces/{space_id}", **kwargs)
 
     def create_space(self, data, **kwargs):
         """Create new space."""
-        return self.post("space", data=data, **kwargs)
+        return self.post("spaces", data=data, **kwargs)
 
     def update_space(self, space_id, data, **kwargs):
         """Update existing space."""
-        return self.put(f"space/{space_id}", data=data, **kwargs)
+        return self.put(f"spaces/{space_id}", data=data, **kwargs)
 
     def delete_space(self, space_id, **kwargs):
         """Delete space."""
-        return self.delete(f"space/{space_id}", **kwargs)
+        return self.delete(f"spaces/{space_id}", **kwargs)
 
     def get_space_content(self, space_id, **kwargs):
         """Get space content."""
-        return self.get(f"space/{space_id}/content", **kwargs)
+        return self.get(f"spaces/{space_id}/content", **kwargs)
 
     # User Management
     def get_users(self, **kwargs):

--- a/atlassian/confluence/cloud/__init__.py
+++ b/atlassian/confluence/cloud/__init__.py
@@ -70,7 +70,8 @@ class Cloud(ConfluenceCloudBase):
 
     # Space Management
     def get_spaces(self, **kwargs):
-        """Get all spaces (single page).
+        """
+        Get all spaces (single page).
 
         Calls the Confluence Cloud v2 endpoint ``/wiki/api/v2/spaces``.
         For paginated enumeration of every space, use :meth:`get_all_spaces`.
@@ -78,7 +79,8 @@ class Cloud(ConfluenceCloudBase):
         return self.get("spaces", **kwargs)
 
     def get_all_spaces(self, **kwargs):
-        """Get all spaces with full pagination.
+        """
+        Get all spaces with full pagination.
 
         Returns a generator yielding each space dict from the Confluence Cloud
         v2 endpoint ``/wiki/api/v2/spaces``. Replaces the legacy v1

--- a/tests/confluence/test_confluence_cloud.py
+++ b/tests/confluence/test_confluence_cloud.py
@@ -150,52 +150,72 @@ class TestConfluenceCloud:
     # Space Management Tests
     @patch.object(ConfluenceCloud, "get")
     def test_get_spaces(self, mock_get, confluence_cloud):
-        """Test get_spaces method."""
+        """get_spaces calls the v2 plural endpoint /wiki/api/v2/spaces."""
         mock_get.return_value = {"results": [{"id": "TEST", "name": "Test Space"}]}
         result = confluence_cloud.get_spaces()
-        mock_get.assert_called_once_with("space", **{})
+        mock_get.assert_called_once_with("spaces", **{})
         assert result == {"results": [{"id": "TEST", "name": "Test Space"}]}
 
     @patch.object(ConfluenceCloud, "get")
+    def test_get_all_spaces_paginates(self, mock_get, confluence_cloud):
+        """get_all_spaces yields every space across paginated v2 responses."""
+        mock_get.side_effect = [
+            {
+                "results": [{"id": "1", "name": "A"}, {"id": "2", "name": "B"}],
+                "_links": {"next": "/wiki/api/v2/spaces?cursor=NEXT"},
+            },
+            {"results": [{"id": "3", "name": "C"}], "_links": {}},
+        ]
+        result = list(confluence_cloud.get_all_spaces())
+        assert result == [
+            {"id": "1", "name": "A"},
+            {"id": "2", "name": "B"},
+            {"id": "3", "name": "C"},
+        ]
+        # Entry-point URL is the v2 plural path; pagination URL handling is
+        # covered by existing _get_paged tests.
+        assert mock_get.call_args_list[0].args[0] == "spaces"
+
+    @patch.object(ConfluenceCloud, "get")
     def test_get_space(self, mock_get, confluence_cloud):
-        """Test get_space method."""
+        """get_space calls the v2 plural endpoint."""
         mock_get.return_value = {"id": "TEST", "name": "Test Space"}
         result = confluence_cloud.get_space("TEST")
-        mock_get.assert_called_once_with("space/TEST", **{})
+        mock_get.assert_called_once_with("spaces/TEST", **{})
         assert result == {"id": "TEST", "name": "Test Space"}
 
     @patch.object(ConfluenceCloud, "post")
     def test_create_space(self, mock_post, confluence_cloud):
-        """Test create_space method."""
+        """create_space calls the v2 plural endpoint."""
         space_data = {"name": "New Space", "key": "NEW"}
         mock_post.return_value = {"id": "NEW", "name": "New Space", "key": "NEW"}
         result = confluence_cloud.create_space(space_data)
-        mock_post.assert_called_once_with("space", data=space_data, **{})
+        mock_post.assert_called_once_with("spaces", data=space_data, **{})
         assert result == {"id": "NEW", "name": "New Space", "key": "NEW"}
 
     @patch.object(ConfluenceCloud, "put")
     def test_update_space(self, mock_put, confluence_cloud):
-        """Test update_space method."""
+        """update_space calls the v2 plural endpoint."""
         space_data = {"name": "Updated Space"}
         mock_put.return_value = {"id": "TEST", "name": "Updated Space"}
         result = confluence_cloud.update_space("TEST", space_data)
-        mock_put.assert_called_once_with("space/TEST", data=space_data, **{})
+        mock_put.assert_called_once_with("spaces/TEST", data=space_data, **{})
         assert result == {"id": "TEST", "name": "Updated Space"}
 
     @patch.object(ConfluenceCloud, "delete")
     def test_delete_space(self, mock_delete, confluence_cloud):
-        """Test delete_space method."""
+        """delete_space calls the v2 plural endpoint."""
         mock_delete.return_value = {"success": True}
         result = confluence_cloud.delete_space("TEST")
-        mock_delete.assert_called_once_with("space/TEST", **{})
+        mock_delete.assert_called_once_with("spaces/TEST", **{})
         assert result == {"success": True}
 
     @patch.object(ConfluenceCloud, "get")
     def test_get_space_content(self, mock_get, confluence_cloud):
-        """Test get_space_content method."""
+        """get_space_content calls the v2 plural endpoint."""
         mock_get.return_value = {"results": [{"id": "123", "title": "Page in Space"}]}
         result = confluence_cloud.get_space_content("TEST")
-        mock_get.assert_called_once_with("space/TEST/content", **{})
+        mock_get.assert_called_once_with("spaces/TEST/content", **{})
         assert result == {"results": [{"id": "123", "title": "Page in Space"}]}
 
     # User Management Tests


### PR DESCRIPTION
Closes #1560.

After commit 63e744f, `Confluence("https://api.atlassian.com/ex/confluence/...")` now routes to the new `Cloud` class, but `get_all_spaces` was dropped from the Cloud surface entirely. Issue reporters in #1560 (and others using OAuth/PAT routed through the gateway) hit `AttributeError` where they previously got a 410.

Cloud's space methods also still call the singular `space` path while `api_root="wiki/api/v2"`, producing `/wiki/api/v2/space[/{id}]` — but the documented v2 endpoint is plural [`/wiki/api/v2/spaces[/{id}]`](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/).

This change:

- Adds `Cloud.get_all_spaces()` returning a paginated generator over `_get_paged("spaces")` — restores the back-compat surface and uses the v2 endpoint.
- Switches `get_spaces`, `get_space`, `create_space`, `update_space`, `delete_space`, `get_space_content` from `space[/...]` to `spaces[/...]`.
- Updates the existing mock-tests for those methods to assert the v2 plural path and adds a pagination test for `get_all_spaces`.

Server is untouched (it uses v1 `space` paths correctly and isn't affected by gateway routing).

### Tests

Full suite green on a clean clone:

```
$ pytest --quiet
514 passed, 6 skipped, 21 warnings in 11.41s

$ pytest tests/confluence/ -v
...
test_get_spaces ............................. PASSED
test_get_all_spaces_paginates ............... PASSED
test_get_space .............................. PASSED
test_create_space ........................... PASSED
test_update_space ........................... PASSED
test_delete_space ........................... PASSED
test_get_space_content ...................... PASSED
... (152 passed)
```

### End-to-end (sanitized — same Cloud tenant, same OAuth bearer, before vs after)

The bearer used here lacks `read:space:confluence` so all four calls land on the gateway's scope check (HTTP 401). What changes between master and this branch is the **method existence** and the **constructed URL path**:

```
# MASTER (commit 2fc67b7)
>>> from atlassian import Confluence
>>> c = Confluence("https://api.atlassian.com/ex/confluence/<cloudid>", token="<bearer>")
>>> c._impl.__class__.__name__
'Cloud'
>>> list(c.get_all_spaces())
AttributeError: 'Cloud' object has no attribute 'get_all_spaces'
>>> c.get_spaces()        # sub-url='space'              → 401 scope mismatch
>>> c.get_space("123")    # sub-url='space/123'          → 401 scope mismatch
>>> c.get_space_content("123")
                          # sub-url='space/123/content'  → 401 scope mismatch
```

```
# THIS BRANCH
>>> list(c.get_all_spaces())
                          # sub-url='spaces' (paginated) → 401 scope mismatch
>>> c.get_spaces()        # sub-url='spaces'             → 401 scope mismatch
>>> c.get_space("123")    # sub-url='spaces/123'         → 401 scope mismatch
>>> c.get_space_content("123")
                          # sub-url='spaces/123/content' → 401 scope mismatch
```

`get_all_spaces` is no longer `AttributeError` and every space sub-url is the documented v2 plural form. A bearer with `read:space:confluence` would get a 200 on the same calls.
