### PR TITLE
[Bitbucket] fix keyerror in repo_users_with_administrator_permissions

### DIFF
--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -1056,7 +1056,7 @@ class Bitbucket(BitbucketBase):
         repo_administrators = []
         for user in self.repo_users(project_key, repo_key):
             if user["permission"] == "REPO_ADMIN":
-                repo_administrators.append(user)
+                repo_administrators.append(user['user'])
         for group in self.repo_groups_with_administrator_permissions(project_key, repo_key):
             for user in self.group_members(group):
                 repo_administrators.append(user)


### PR DESCRIPTION
The error:
```
(.venv) C:\DeveloperFiles\Repos\reporter\bitbucket-reporter>python test.py
Traceback (most recent call last):
  File "C:\DeveloperFiles\Repos\reporter\bitbucket-reporter\test.py", line 11, in <module>
    response = client.repo_users_with_administrator_permissions(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\DeveloperFiles\Repos\reporter\bitbucket-reporter\.venv\Lib\site-packages\atlassian\bitbucket\__init__.py", line 1068, in repo_users_with_administrator_permissions
    return list({user["id"]: user for user in repo_administrators}.values())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\DeveloperFiles\Repos\reporter\bitbucket-reporter\.venv\Lib\site-packages\atlassian\bitbucket\__init__.py", line 1068, in <dictcomp>
    return list({user["id"]: user for user in repo_administrators}.values())
                 ~~~~^^^^^^
KeyError: 'id'
```

Adding the 3 following debug lines:
```
    def repo_users_with_administrator_permissions(self, project_key, repo_key):
        """
        Get repository administrators for repository
        :param project_key: The project key
        :param repo_key: The repository key
        :return: List of repo administrators
        """
        repo_administrators = []
        for user in self.repo_users(project_key, repo_key):
            if user["permission"] == "REPO_ADMIN":
                **print(f"User structure is: {user}")
                print(f"User dictionary keys: {list(user.keys())}")
                print(f"User dictionary 'user' key value: {user['user']}")**
                repo_administrators.append(user['user'])
        for group in self.repo_groups_with_administrator_permissions(project_key, repo_key):
            for user in self.group_members(group):
                repo_administrators.append(user)
        for user in self.project_users_with_administrator_permissions(project_key):
            repo_administrators.append(user)

        # We convert to a set to ensure uniqueness then back to a list for later useability
        return list({user["id"]: user for user in repo_administrators}.values())
```

Outputs:
```
(.venv) C:\DeveloperFiles\Repos\reporter\bitbucket-reporter>python test.py
User structure is: {'user': {'name': 'dummyName', 'emailAddress': 'dummy_name@email.com', 'active': True, 'displayName': 'NAME, Dummy', 'id': 123456, 'slug': 'dummyName', 'type': 'NORMAL', 'links': {'self': [{'href': 'https://bitbucket.int.corp.sun/users/dummyName'}]}}, 'permission': 'REPO_ADMIN'}
User dictionary keys: ['user', 'permission']
User dictionary 'user' key value: {'name': 'dummyName', 'emailAddress': 'dummy_name@email.com', 'active': True, 'displayName': 'NAME, Dummy', 'id': 123456, 'slug': 'dummyName', 'type': 'NORMAL', 'links': {'self': [{'href': 'https://bitbucket.int.corp.sun/users/dummyName'}]}}
```