### PR TITLE
[JIRA] Improve typing experience of Jira instanziation

### DIFF
--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -15,7 +15,7 @@ else:
     from typing_extensions import Literal  # Python <=3.7
 from .errors import ApiNotFoundError, ApiPermissionError
 from .rest_client import AtlassianRestAPI
-from .typehints import T_id, T_resp_json
+from .typehints import T_id, T_resp_json, copy_type
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ class Jira(AtlassianRestAPI):
     Reference: https://docs.atlassian.com/software/jira/docs/api/REST/8.5.0/#api/2
     """
 
+    @copy_type(AtlassianRestAPI.__init__)
     def __init__(self, url: str, *args: Any, **kwargs: Any):
         if "api_version" not in kwargs:
             kwargs["api_version"] = "2"

--- a/atlassian/typehints.py
+++ b/atlassian/typehints.py
@@ -1,7 +1,13 @@
-from typing import Union
+from typing import Union, TypeVar, Callable, Any
 
 from typing_extensions import TypeAlias
 
 T_id: TypeAlias = Union[str, int]
 _Data: TypeAlias = Union[dict, str]
 T_resp_json: TypeAlias = Union[dict, None]
+
+_T = TypeVar("T")
+
+def copy_type(_:_T) -> Callable[[Any], _T]:
+    """Decorator to inherit typing from parent."""
+    return lambda x: x


### PR DESCRIPTION
Hi!

Sorry for this out of the blue, just got a bit annoyed when using the Jira API. Made a little patch for my self and thought that the community would like it aswell. 

Make `Jira()` type nicer with inheritance of parent function signature. Works well when just passing through `*args` `**kwargs`.

*Note: `g(f(x))` calling overhead of the decorator should not be noticeable as the `Jira` object only init once.*


Patch provides completion capabilities for more editors:
<img width="984" height="548" alt="image" src="https://github.com/user-attachments/assets/3587826c-341c-416a-b738-ceb558b5f2ea" />


Credits to [typing#769](https://github.com/python/typing/issues/769#issuecomment-903760354) for the pattern.