### PR TITLE
GitHub: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable automated dependency update PRs for
two ecosystems detected in this repo:

- **pip** — Python dependencies (`requirements.txt`, `setup.py`, `pyproject.toml`)
- **github-actions** — workflow action pins (`.github/workflows/`)

Configuration choices:
- Weekly update schedule (good balance between staying current and reducing PR noise)
- Updates grouped per ecosystem into a single PR (reduces total PR count)

## Why

The repo has no existing Dependabot or Renovate configuration, so dependencies
are only updated manually. Enabling Dependabot means security patches and new
releases surface automatically as reviewable PRs, without any ongoing manual
tracking.

This change was generated by [Autar](https://autar.ai) and reviewed by a
human before submission.
