### PR TITLE
Fix AssetsCloud.get_object_type_attributes sending snake_case query params the API ignores

### DIFF
--- a/atlassian/assets.py
+++ b/atlassian/assets.py
@@ -538,9 +538,16 @@ class AssetsCloud(AtlassianRestAPI):
             order_by_required (bool, optional): Order by required fields, defaults to None (Use API default)
         """
 
-        kwargs = list(locals().items())
-        params = dict()
-        params.update({k: v for k, v in kwargs if v is not None and k not in ["self", "type_id"]})
+        params = {
+            "onlyValueEditable": only_value_editable,
+            "orderByName": order_by_name,
+            "query": query,
+            "includeValuesExist": include_values_exist,
+            "excludeParentAttributes": exclude_parent_attributes,
+            "includeChildren": include_children,
+            "orderByRequired": order_by_required,
+        }
+        params = {k: v for k, v in params.items() if v is not None}
 
         return self.get(
             f"{self.api_root}/objecttype/{type_id}/attributes",

--- a/tests/test_assets_object_type_attributes.py
+++ b/tests/test_assets_object_type_attributes.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from atlassian import AssetsCloud
+
+
+class TestAssetsObjectTypeAttributes(TestCase):
+    def test_query_params_use_the_documented_api_names(self):
+        assets = AssetsCloud("https://example.atlassian.net")
+
+        with patch.object(assets, "get", return_value={}) as get:
+            assets.get_object_type_attributes(
+                "1",
+                only_value_editable=True,
+                order_by_name=True,
+                query="name",
+                include_values_exist=True,
+                exclude_parent_attributes=True,
+                include_children=True,
+                order_by_required=True,
+            )
+
+        params = get.call_args.kwargs["params"]
+        self.assertEqual(
+            params,
+            {
+                "onlyValueEditable": True,
+                "orderByName": True,
+                "query": "name",
+                "includeValuesExist": True,
+                "excludeParentAttributes": True,
+                "includeChildren": True,
+                "orderByRequired": True,
+            },
+        )
+
+    def test_unset_params_are_still_omitted(self):
+        assets = AssetsCloud("https://example.atlassian.net")
+
+        with patch.object(assets, "get", return_value={}) as get:
+            assets.get_object_type_attributes("1", include_children=True)
+
+        self.assertEqual(get.call_args.kwargs["params"], {"includeChildren": True})
+
+    def test_type_id_is_not_sent_as_a_query_param(self):
+        assets = AssetsCloud("https://example.atlassian.net")
+
+        with patch.object(assets, "get", return_value={}) as get:
+            assets.get_object_type_attributes("1")
+
+        self.assertEqual(get.call_args.kwargs["params"], {})
+        self.assertIn("objecttype/1/attributes", get.call_args.args[0])


### PR DESCRIPTION
`AssetsCloud.get_object_type_attributes` builds its query string from `locals()`, so it sends the Python parameter names straight through:

```python
kwargs = list(locals().items())
params = dict()
params.update({k: v for k, v in kwargs if v is not None and k not in ["self", "type_id"]})
```

That puts `only_value_editable`, `order_by_name`, `include_values_exist`, `exclude_parent_attributes`, `include_children` and `order_by_required` on the request. The endpoint documents `onlyValueEditable`, `orderByName`, `includeValuesExist`, `excludeParentAttributes`, `includeChildren` and `orderByRequired`, so it ignores all six. Only `query` works, because it's spelled the same either way.

So `get_object_type_attributes(type_id, include_children=True)` returns the same thing as `get_object_type_attributes(type_id)`.

`get_object_schema_object_types_flat`, eighteen lines above, uses the identical `locals()` idiom and is fine, because its parameter names already match the API, `includeObjectCounts` included. That's what made me think the other one was an oversight and not a deliberate naming choice.

The change maps the names explicitly and keeps the `is not None` filter, so the Python signature is unchanged and nothing breaks for existing callers.

Added `tests/test_assets_object_type_attributes.py`. The first two tests fail on master and pass with the change, and the third pins that `type_id` stays out of the query string. Your suite goes from 949 passed, 10 skipped to 952 passed, 10 skipped.

`Insight.get_object_type_attributes` in `atlassian/insight.py` is the same code with the same docstring link. I left it alone, since that class defaults to the on-premise `rest/insight/1.0` API and I have no way to check what parameter names that one accepts. Happy to include it if you know.
