### PR TITLE
Pass expand via params in ConfluenceServer.get_page_space

### DIFF
--- a/atlassian/confluence/server/__init__.py
+++ b/atlassian/confluence/server/__init__.py
@@ -238,7 +238,7 @@ class Server(ConfluenceServerBase):
 
     def get_page_space(self, page_id):
         """Get space key from page ID."""
-        page = self.get_content(page_id, expand="space")
+        page = self.get(f"content/{page_id}", params={"expand": "space"})
         return page.get("space", {}).get("key")
 
     def get_page_child_by_type(self, page_id, type="page", start=None, limit=None, expand=None):

--- a/tests/confluence/test_confluence_server.py
+++ b/tests/confluence/test_confluence_server.py
@@ -927,8 +927,25 @@ class TestConfluenceServer:
         """Test get_page_space method."""
         mock_get.return_value = {"space": {"key": "TEST"}}
         result = confluence_server.get_page_space("123")
-        mock_get.assert_called_once_with("content/123", expand="space")
+        mock_get.assert_called_once_with("content/123", params={"expand": "space"})
         assert result == "TEST"
+
+    def test_get_page_space_uses_expand_query_param(self, confluence_server):
+        """get_page_space must pass expand via params so AtlassianRestAPI.get() accepts the call."""
+        response = Response()
+        response.status_code = 200
+        response.reason = "OK"
+        response._content = b'{"space": {"key": "TEST"}}'
+
+        with patch.object(confluence_server._session, "request", return_value=response) as mock_request:
+            result = confluence_server.get_page_space("123")
+
+        assert result == "TEST"
+        url = mock_request.call_args.kwargs["url"]
+        params = mock_request.call_args.kwargs.get("params") or {}
+        assert url.startswith("https://test.confluence.com/rest/api/content/123")
+        expand = params.get("expand") if isinstance(params, dict) else None
+        assert expand == "space" or "expand=space" in url
 
     # Space Management Tests
     @patch.object(ConfluenceServer, "get")


### PR DESCRIPTION
## Summary
- `ConfluenceServer.get_page_space` was calling `get_content(..., expand="space")`, which forwarded `expand` into `AtlassianRestAPI.get()`. That method does not accept `expand`, so 5.0.0+ raises `TypeError`.
- Pass `params={"expand": "space"}` on `GET content/{page_id}`, matching Cloud and other Server helpers.
- Add a test that goes through the real `get()` / session path.

Credit @TechVoyager.

Fixes #1663.