### PR TITLE
Improve get_page_id method to return None if no results found

### DIFF
--- a/atlassian/confluence/server/__init__.py
+++ b/atlassian/confluence/server/__init__.py
@@ -337,13 +337,16 @@ class Server(ConfluenceServerBase):
 
     def get_page_id(self, space, title, type="page"):
         """
-        Provide content id from search result by title and space.
+        Get page ID by searching for it by space key and title - returns the ID from the first result or None if not found.
         :param space: SPACE key
         :param title: title
         :param type: type of content: Page or Blogpost. Defaults to page
         :return:
         """
-        return (self.get_page_by_title(space, title, type=type) or {}).get("id")
+        json_response = self.get_page_by_title(space, title, type=type)
+        if json_response and "results" in json_response and len(json_response["results"]) > 0:
+            return json_response["results"][0]["id"]
+        return None
 
     def get_parent_content_id(self, page_id):
         """


### PR DESCRIPTION
In the new Atlassian 2.0 REST we get below response when we call `get_page_by_title(space, title, type=type)`for the Confluence Server. 

**Current Problem**
The existing response does not consider the new Response structure : ` return (self.get_page_by_title(space, title, type=type) or {}).get("id")` which is eventually returning NONE for all the page_id.

**What the PR aims to solve?**
This PR will consider the new Payload structure as per the new Confluence V2 REST API response and return the correct page_id.


**new Confluence V2 REST API response**
```
{
    "results": [
        {
            "id": "111111111",
            "type": "page",
            "status": "current",
            "title": "Page Title",
            "position": 17,
            "extensions": {
                "position": 17
            },
            "_links": {
                "webui": "/spaces/<SPACE>/pages/111111111/Page+Title",
                "edit": "/pages/resumedraft.action?draftId=111111111&draftShareId=11a1e1b1-1111-1111-a111-1111bcac1111",
                "tinyui": "/x/AaAAA",
                "self": "[https://confluence.mine/rest/api/content/111111111](https://confluence.mine/rest/api/content/111111111)"
            },
            "_expandable": {
                "container": "/rest/api/space/<SPACE>",
                "metadata": "",
                "operations": "",
                "children": "/rest/api/content/111111111/child",
                "restrictions": "/rest/api/content/111111111/restriction/byOperation",
                "history": "/rest/api/content/111111111/history",
                "ancestors": "",
                "body": "",
                "version": "",
                "descendants": "/rest/api/content/111111111/descendant",
                "space": "/rest/api/space/<SPACE>",
                "relevantViewRestrictions": "/rest/api/content/111111111/restriction/relevantViewRestrictions"
            }
        }
    ],
    "start": 0,
    "limit": 25,
    "size": 1,
    "_links": {
        "self": "[https://confluence.mine/rest/api/content?spaceKey=<SPACE>&title=Page+Title&type=page](https://confluence.mine/rest/api/content?spaceKey=<SPACE>&title=Page+Title&type=page)",
        "base": "[https://confluence.mine](https://confluence.mine/)",
        "context": ""
    }
}
```

Verified the changes as per this https://github.com/atlassian-api/atlassian-python-api/issues/1658#issuecomment-5359586878 and https://github.com/atlassian-api/atlassian-python-api/issues/1658#issuecomment-5367054871 PR issue discussion. 